### PR TITLE
Added python dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,4 +51,6 @@ Requirements
 
 * PDAL 1.7+
 * Python >=2.7 (including Python 3.x)
+* Cython (eg :code:`pip install cython`)
+* Packaging (eg :code:`pip install packaging`) 
 


### PR DESCRIPTION
Python modules Cython and Packaging are needed to install the PDAL Python extension, it seems useful to list them as requirements with an example of how to install them