### PR TITLE
Add D_GLIBCXX_USE_CXX11_ABI=0 to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ if pdal_config and "clean" not in sys.argv:
 include_dirs.append(numpy.get_include())
 
 if os.name != 'nt':
-    extra_compile_args = ['-std=c++11','-Wno-unknown-pragmas']
+    extra_compile_args = ['-D_GLIBCXX_USE_CXX11_ABI=0', '-std=c++11','-Wno-unknown-pragmas']
 
 if platform.system() == 'Darwin':
     extra_link_args.append('-Wl,-rpath,'+library_dirs[0])


### PR DESCRIPTION
Fix for #16.

Tested on my Linux box. `import pdal` now works without the "ImportError: ... with undefined symbol _ZN4pdal6Config16debugInformationB5cxx11Ev". Pending review that it works on other systems.

To test, install from fork (preferably in a virtual environment) using `python -m pip install -e git+https://github.com/weiji14/pdal-python.git@abi_fix#egg=pdal`
