### PR TITLE
Pythonic pipeline construction sugar proposal?

### DIFF
--- a/pdal/pio.py
+++ b/pdal/pio.py
@@ -11,8 +11,6 @@ import pdal
 
 PDAL_DRIVERS_JSON = subprocess.run(["pdal", "--drivers", "--showjson"], capture_output=True).stdout
 PDAL_DRIVERS = json.loads(PDAL_DRIVERS_JSON)
-modules = set([e["name"].split(".")[0] for e in PDAL_DRIVERS])
-
 
 DEFAULT_STAGE_PARAMS = defaultdict(dict)
 DEFAULT_STAGE_PARAMS.update({

--- a/pdal/pio.py
+++ b/pdal/pio.py
@@ -52,7 +52,7 @@ class StageSpec(object):
         return self.pipeline + other
 
     def __dir__(self):
-        extra_keys = [e["name"][len(self.key):] for e in PDAL_DRIVERS if e["name"].startswith(self.key)]
+        extra_keys = [e["name"][len(self.key):] for e in PDAL_DRIVERS if e["name"].startswith(self.key)] + ["auto"]
         return super().__dir__() + [e for e in extra_keys if len(e) > 0]
 
     def execute(self):

--- a/pdal/pio.py
+++ b/pdal/pio.py
@@ -56,7 +56,7 @@ class PipelineSpec(object):
         if other is not None:
             self.readers = copy.copy(other.readers)
             self.filters = copy.copy(other.filters)
-            self.writer = copy.copy(other.writer)
+            self.writer = other.writer
 
     @property
     def spec(self):

--- a/pdal/pio.py
+++ b/pdal/pio.py
@@ -38,7 +38,8 @@ class StageSpec(object):
         return output
 
     def __getattr__(self, name):
-        assert name in dir(self), "Invalid or unsupported stage"
+        if name not in dir(self):
+            raise AttributeError(f"'{self.prefix}.{name}' is an invalid or unsupported PDAL stage")
         return partial(self.__class__, self.prefix, type=name)
 
     def __str__(self):

--- a/pdal/pio.py
+++ b/pdal/pio.py
@@ -31,7 +31,7 @@ class StageSpec(object):
         self.spec.update(kwargs)
         self.spec["type"] = self.key
         # NOTE: special case to support reading files without passing an explicit reader
-        if (self.prefix == "readers") and kwargs.get("type") == "auto":
+        if (self.prefix in ["readers", "writers"]) and kwargs.get("type") == "auto":
             del self.spec["type"]
 
     @property

--- a/pdal/pio.py
+++ b/pdal/pio.py
@@ -9,8 +9,13 @@ import warnings
 
 import pdal
 
-PDAL_DRIVERS_JSON = subprocess.run(["pdal", "--drivers", "--showjson"], capture_output=True).stdout
-PDAL_DRIVERS = json.loads(PDAL_DRIVERS_JSON)
+try:
+    PDAL_DRIVERS_JSON = subprocess.run(["pdal", "--drivers", "--showjson"], capture_output=True).stdout
+    PDAL_DRIVERS = json.loads(PDAL_DRIVERS_JSON)
+    _PDAL_VALIDATE = True
+except:
+    PDAL_DRIVERS = []
+    _PDAL_VALIDATE = False
 
 DEFAULT_STAGE_PARAMS = defaultdict(dict)
 DEFAULT_STAGE_PARAMS.update({
@@ -36,7 +41,7 @@ class StageSpec(object):
         return output
 
     def __getattr__(self, name):
-        if name not in dir(self):
+        if _PDAL_VALIDATE and (name not in dir(self)):
             raise AttributeError(f"'{self.prefix}.{name}' is an invalid or unsupported PDAL stage")
         return partial(self.__class__, self.prefix, type=name)
 

--- a/pdal/pio.py
+++ b/pdal/pio.py
@@ -65,15 +65,11 @@ writers = StageSpec("writers")
 
 
 class PipelineSpec(object):
-    readers = []
-    filters = []
-    writer = None
+    stages = []
 
     def __init__(self, other=None):
         if other is not None:
-            self.readers = copy.copy(other.readers)
-            self.filters = copy.copy(other.filters)
-            self.writer = other.writer
+            self.stages = copy.copy(other.stages)
 
     @property
     def spec(self):
@@ -81,26 +77,10 @@ class PipelineSpec(object):
             "pipeline": [stage.spec for stage in self.stages]
         }
 
-    @property
-    def stages(self):
-        if self.writer is not None:
-            return chain(self.readers, self.filters, [self.writer])
-        else:
-            return chain(self.readers, self.filters)
-
     def add_stage(self, stage):
         assert isinstance(stage, StageSpec), "Expected StageSpec"
-        if stage.prefix == "writers":
-            if self.writer is not None:
-                warnings.warn("Currently assigned output stage will be replaced.")
-            self.writer = stage
-        elif stage.prefix == "readers":
-            self.readers.append(stage)
-        elif stage.prefix == "filters":
-            self.filters.append(stage)
-        else:
-            warnings.warn("Unknown stage type.  Skipping.")
 
+        self.stages.append(stage)
         return self
 
     def __str__(self):

--- a/pdal/pio.py
+++ b/pdal/pio.py
@@ -1,0 +1,111 @@
+import json
+from functools import partial
+from collections import defaultdict
+from itertools import chain
+import copy
+import warnings
+
+import pdal
+
+DEFAULT_STAGE_PARAMS = defaultdict(dict)
+DEFAULT_STAGE_PARAMS.update({
+# TODO: add stage specific default configurations
+})
+
+class StageSpec(object):
+    def __init__(self, prefix, **kwargs):
+        self.prefix = prefix
+        key = ".".join([self.prefix, kwargs.get("type", "")])
+        self.spec = DEFAULT_STAGE_PARAMS[key].copy()
+        self.spec.update(kwargs)
+        self.spec["type"] = key
+        # NOTE: special case to support reading files without passing an explicit reader
+        if (self.prefix == "readers") and kwargs.get("type") == "auto":
+            del self.spec["type"]
+
+    @property
+    def pipeline(self):
+        output = PipelineSpec()
+        output.add_stage(self)
+        return output
+
+    def __getattr__(self, name):
+        return partial(self.__class__, self.prefix, type=name)
+
+    def __str__(self):
+        return json.dumps(self.spec, indent=4)
+
+    def __add__(self, other):
+        return self.pipeline + other
+
+    def execute(self):
+        return self.pipeline.execute()
+
+
+readers = StageSpec("readers")
+filters = StageSpec("filters")
+writers = StageSpec("writers")
+
+
+class PipelineSpec(object):
+    readers = []
+    filters = []
+    writer = None
+
+    def __init__(self, other=None):
+        if other is not None:
+            self.readers = copy.copy(other.readers)
+            self.filters = copy.copy(other.filters)
+            self.writer = copy.copy(other.writer)
+
+    @property
+    def spec(self):
+        return {
+            "pipeline": [stage.spec for stage in self.stages]
+        }
+
+    @property
+    def stages(self):
+        if self.writer is not None:
+            return chain(self.readers, self.filters, [self.writer])
+        else:
+            return chain(self.readers, self.filters)
+
+    def add_stage(self, stage):
+        assert isinstance(stage, StageSpec), "Expected StageSpec"
+        if stage.prefix == "writers":
+            if self.writer is not None:
+                warnings.warn("Currently assigned output stage will be replaced.")
+            self.writer = stage
+        elif stage.prefix == "readers":
+            self.readers.append(stage)
+        elif stage.prefix == "filters":
+            self.filters.append(stage)
+        else:
+            warnings.warn("Unknown stage type.  Skipping.")
+
+        return self
+
+    def __str__(self):
+        return json.dumps(self.spec, indent=4)
+
+    def __add__(self, stage_or_pipeline):
+        assert isinstance(stage_or_pipeline, (StageSpec, PipelineSpec)), "Expected StageSpec or PipelineSpec"
+
+        output = self.__class__(self)
+        if isinstance(stage_or_pipeline, StageSpec):
+            output.add_stage(stage_or_pipeline)
+        elif isinstance(stage_or_pipeline, PipelineSpec):
+            for stage in stage_or_pipeline.stages:
+                output.add_stage(stage)
+        return output
+
+    def execute(self):
+        # TODO: do some validation before calling execute
+
+        # TODO: some exception/error handling around pdal
+        pipeline = pdal.Pipeline(json.dumps(self.spec))
+        # pipeline.validate() # NOTE: disabling this because it causes segfaults in certain cases
+        pipeline.execute()
+
+        return pipeline.arrays[0] # NOTE: are there situation where arrays has multiple elements?

--- a/test/test_pio.py
+++ b/test/test_pio.py
@@ -45,3 +45,13 @@ class TestPIOBasics(unittest.TestCase):
         self.assertIsInstance(pipeline, pio.PipelineSpec)
         self.assertEqual(len(list(pipeline.stages)), 5)
         self.assertEqual(json.dumps(pipeline.spec, indent=2), dummy_pipeline)
+
+        auto_reader = pio.readers.auto(filename="dummyinput.las")
+        auto_writer = pio.writers.auto(filename="dummyoutput.las")
+
+        self.assertIn("filename", auto_reader.spec)
+        self.assertNotIn("type", auto_reader.spec)
+        self.assertIn("filename", auto_reader.spec)
+        self.assertNotIn("type", auto_writer.spec)
+        self.assertEqual(auto_reader.prefix, "readers")
+        self.assertEqual(auto_writer.prefix, "writers")

--- a/test/test_pio.py
+++ b/test/test_pio.py
@@ -1,0 +1,47 @@
+import unittest
+import json
+
+from pdal import pio
+
+dummy_pipeline = """{
+  "pipeline": [
+    {
+      "type": "readers.ply",
+      "filename": "dummyinput.ply"
+    },
+    {
+      "type": "filters.outlier",
+      "method": "statistical",
+      "mean_k": 16,
+      "multiplier": 1.0
+    },
+    {
+      "type": "filters.range",
+      "limits": "Classification![7:7]"
+    },
+    {
+      "type": "filters.normal"
+    },
+    {
+      "type": "writers.ply",
+      "storage_mode": "ascii",
+      "precision": 4,
+      "filename": "dummyoutput.ply",
+      "dims": "X,Y,Z,Red,Green,Blue,NormalX,NormalY,NormalZ"
+    }
+  ]
+}"""
+
+
+
+class TestPIOBasics(unittest.TestCase):
+    def test_pipeline_construction(self):
+        pipeline = (pio.readers.ply(filename="dummyfile.ply") +
+                    pio.filters.outlier(method="statistical", mean_k=16, multiplier=1.0) +
+                    pio.filters.range(limits="Classification![7:7]") +
+                    pio.filters.normal() + pio.writers.ply(storage_mode="ascii", precision=4, filename=output,
+                                                           dims="X,Y,Z,Red,Green,Blue,NormalX,NormalY,NormalZ"))
+
+        self.assertTrue(isinstance(pipeline, pio.PipelineSpec))
+        self.assertEqual(len(list(pipeline.stages)), 5)
+        self.assertEqual(json.dumps(pipeline.spec, indent=2, dummy_pipeline)

--- a/test/test_pio.py
+++ b/test/test_pio.py
@@ -36,12 +36,21 @@ dummy_pipeline = """{
 
 class TestPIOBasics(unittest.TestCase):
     def test_pipeline_construction(self):
-        pipeline = (pio.readers.ply(filename="dummyfile.ply") +
+        pipeline = (pio.readers.ply(filename="dummyinput.ply") +
                     pio.filters.outlier(method="statistical", mean_k=16, multiplier=1.0) +
                     pio.filters.range(limits="Classification![7:7]") +
-                    pio.filters.normal() + pio.writers.ply(storage_mode="ascii", precision=4, filename=output,
+                    pio.filters.normal() + pio.writers.ply(storage_mode="ascii", precision=4, filename="dummyoutput.ply",
                                                            dims="X,Y,Z,Red,Green,Blue,NormalX,NormalY,NormalZ"))
 
-        self.assertTrue(isinstance(pipeline, pio.PipelineSpec))
+        self.assertIsInstance(pipeline, pio.PipelineSpec)
         self.assertEqual(len(list(pipeline.stages)), 5)
-        self.assertEqual(json.dumps(pipeline.spec, indent=2, dummy_pipeline)
+        self.assertEqual(json.dumps(pipeline.spec, indent=2), dummy_pipeline)
+
+        pipeline = pipeline + pio.readers.auto(filename="anotherdummmyfile.laz")
+
+        self.assertEqual(len(pipeline.readers), 2) # we can have multiple readers
+
+        null_writer = pio.writers.null()
+        self.assertIsNot(pipeline.writer, null_writer)
+        pipeline = pipeline + null_writer
+        self.assertIs(pipeline.writer, null_writer)

--- a/test/test_pio.py
+++ b/test/test_pio.py
@@ -45,12 +45,3 @@ class TestPIOBasics(unittest.TestCase):
         self.assertIsInstance(pipeline, pio.PipelineSpec)
         self.assertEqual(len(list(pipeline.stages)), 5)
         self.assertEqual(json.dumps(pipeline.spec, indent=2), dummy_pipeline)
-
-        pipeline = pipeline + pio.readers.auto(filename="anotherdummmyfile.laz")
-
-        self.assertEqual(len(pipeline.readers), 2) # we can have multiple readers
-
-        null_writer = pio.writers.null()
-        self.assertIsNot(pipeline.writer, null_writer)
-        pipeline = pipeline + null_writer
-        self.assertIs(pipeline.writer, null_writer)


### PR DESCRIPTION
Thought I'd see if this kind interface would be of interest.  In the same spirit as #21, this is a module that allows pipelines to be constructed a bit more easily in python, without using an explicit vocabulary.  Constructing a pipeline using this module looks like this:

```Python
from pdal import pio
pipeline = (pio.readers.ply(filename="dummyinput.ply") +
            pio.filters.outlier(method="statistical", mean_k=16, multiplier=1.0) +
            pio.filters.range(limits="Classification![7:7]") +
            pio.filters.normal() + pio.writers.ply(storage_mode="ascii", precision=4, filename="dummyoutput.ply",
                                                    dims="X,Y,Z,Red,Green,Blue,NormalX,NormalY,NormalZ"))
```

To execute a pipeline and return the numpy structured array.  I've been parsing this into an [Open3D](https://github.com/intel-isl/Open3D) point cloud but didn't want to introduce the dependency, and restrict the possible fields for no reason.

```Python
data = pipeline.execute()
```

There is a special case for not having to specify a reader that looks like this `pio.readers.auto(filename="someones.las")`.  Readers can be executed directly which means that reading data that pdal understands into numpy can look like this:

```Python
data = pio.readers.auto(filename="someones.las").execute()
```

`pipeline.spec` builds/holds the dict from which the json pipeline is generated, in case that needs to be inspected.  Multiple reader stages are supported, but writers get replaced.  I think that matches current supported behavior.

Is this a direction that looks interesting?  I think to make it useful some validation would be good but unfortunately we're currently running into segfaults trying to use `pdal.Pipeline.validate()` in some cases (which I'm guessing is related #23).  Also, I prob used some Python 3.x specific things, not sure if  that's an issue. Anyway, curious to hear any thoughts.