### PR TITLE
Fix memory leak

### DIFF
--- a/pdal/libpdalpython.pyx
+++ b/pdal/libpdalpython.pyx
@@ -155,7 +155,6 @@ cdef class PyPipeline:
                 a = ptr#.get()
                 o = a.getPythonArray()
                 output.append(<object>o)
-                del ptr
                 inc(it)
             return output
 

--- a/pdal/libpdalpython.pyx
+++ b/pdal/libpdalpython.pyx
@@ -155,6 +155,7 @@ cdef class PyPipeline:
                 a = ptr#.get()
                 o = a.getPythonArray()
                 output.append(<object>o)
+                del ptr
                 inc(it)
             return output
 


### PR DESCRIPTION
This code from https://github.com/PDAL/python/blob/3d94698d789f6dcb498a2cb127c06e49d1cd89e1/pdal/PyPipeline.cpp#L169
```python
    for (auto i: pvset)
    {
        //ABELL - Leak?
        Array *array = new python::Array;
        array->update(i);
        output.push_back(array);
    }
```

allocates an array for each `pvset` but the arrays were were never released. This PR Fixes this  by releasing the memory of the c++ arrays used to pass the data to the python binding.

Closes #23 

