### PR TITLE
Allow using "filters.python" in a python process on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,14 @@ macro(PDAL_PYTHON_ADD_TEST _name)
 #    endif()
 endmacro(PDAL_PYTHON_ADD_TEST)
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # For newer versions of python (3.8+), C extensions don't link against
+    # libpython and instead get symbol definitions from the python interpreter
+    # executable. PDAL plugins need to link against libpython, but if a plugin
+    # is loaded inside a python process, it must resolve symbols from the python
+    # executable instead of libpython. Using flat namespace allows that.
+    set(PYTHON_LINK_LIBRARY ${PYTHON_LINK_LIBRARY} -Wl,-flat_namespace)
+endif()
 
 PDAL_PYTHON_ADD_PLUGIN(numpy_reader reader numpy
     FILES

--- a/test/test_pypy.py
+++ b/test/test_pypy.py
@@ -1,0 +1,26 @@
+import unittest
+import json
+import pdal
+import numpy
+import os
+
+DATADIRECTORY = "./test/data"
+
+
+def a_filter(ins, outs):
+    return True
+
+
+class TestPythonInPython(unittest.TestCase):
+    def test_pipeline_construction(self):
+
+        pipeline = [
+            os.path.join(DATADIRECTORY, "autzen-utm.las"),
+            {
+                "type": "filters.python",
+                "script": __file__,
+                "function": "a_filter",
+                "module": "anything",
+            },
+        ]
+        pdal.Pipeline(json.dumps(pipeline)).execute()


### PR DESCRIPTION
This fixes https://github.com/PDAL/python/issues/75