### PR TITLE
Add Meshes to the pdal API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/*
 *.o
 *.so
 *.dylib
+.DS_Store

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -149,16 +149,48 @@ Description: ===================================================================
         count = p.execute()
         print (count)
 
+    Accessing Mesh Data
+    ................................................................................
+
+    Some PDAL stages (for instance ``filters.delaunay``) create TIN type mesh data. 
+
+    This data can be accessed in Python using the ``Pipeline.meshes`` property, which returns ``numpy.ndarray`` 
+    of shape (1,n) where n is the number of Triangles in the mesh. If the PointView contains no mesh data, then n = 0.
+
+    Each Triangle is a tuple ``(A,B,C)`` where A, B and C are indicees into the PointView for the point that is the vertex for the Triangle.
+
+    Meshio Integration
+    ................................................................................
+
+    The meshes property provides the face data but is not easy to use as a mesh. Therefore, we have provided optional Integration
+    into the `Meshio <https://github.com/nschloe/meshio>`__ library.
+
+    The ``pdal.Pipeline`` class provides the ``get_meshio(idx: int) -> meshio.Mesh`` method. This 
+    method creates a `Mesh` object from the `PointView` array and mesh properties.
+
+    .. note:: The meshio integration requires that meshio is installed (e.g. ``pip install meshio``). If it
+    is not, then the method fails with an informative RuntimeError.
+
+    Simple use of the functionality could be as follows:
+
+    -- code-block:: python
+      import pdal
+
+      ...
+      pl = pdal.Pipeline(pipeline)
+      pl.execute()
+
+      mesh = pl.get_meshio(0)
+      mesh.write('test.obj')
 
 
+        .. _`Numpy`: http://www.numpy.org/
+        .. _`schema`: http://www.pdal.io/dimensions.html
+        .. _`metadata`: http://www.pdal.io/development/metadata.html
 
-    .. _`Numpy`: http://www.numpy.org/
-    .. _`schema`: http://www.pdal.io/dimensions.html
-    .. _`metadata`: http://www.pdal.io/development/metadata.html
 
-
-    .. image:: https://ci.appveyor.com/api/projects/status/of4kecyahpo8892d
-       :target: https://ci.appveyor.com/project/hobu/python/
+        .. image:: https://ci.appveyor.com/api/projects/status/of4kecyahpo8892d
+          :target: https://ci.appveyor.com/project/hobu/python/
 
     Requirements
     ================================================================================

--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,7 @@ method creates a `Mesh` object from the `PointView` array and mesh properties.
 Simple use of the functionality could be as follows:
 
 .. code-block:: python
+    
     import pdal
 
     ...

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ sorts it by the ``X`` dimension:
     metadata = pipeline.metadata
     log = pipeline.log
 
-Reading  using Numpy Arrays
+Reading using Numpy Arrays
 ................................................................................
 
 The following more complex scenario demonstrates the full cycling between
@@ -147,6 +147,83 @@ PDAL and Python:
     count = p.execute()
     print (count)
 
+
+Accessing Mesh Data
+................................................................................
+
+Some PDAL stages (for instance ``filters.delaunay``) create TIN type mesh data. 
+
+This data can be accessed in Python using the ``Pipeline.meshes`` property, which returns ``numpy.ndarray`` 
+of shape (1,n) where n is the number of Triangles in the mesh. If the PointView contains no mesh data, then n = 0.
+
+Each Triangle is a tuple ``(A,B,C)`` where A, B and C are indicees into the PointView for the point that is the vertex for the Triangle.
+
+Meshio Integration
+................................................................................
+
+The meshes property provides the face data but is not easy to use as a mesh. Therefore, we have provided optional Integration
+into the `Meshio <https://github.com/nschloe/meshio>`__ library.
+
+The ``pdal.Pipeline`` class provides the ``get_meshio(idx: int) -> meshio.Mesh`` method. This 
+method creates a `Mesh` object from the `PointView` array and mesh properties.
+
+.. note:: The meshio integration requires that meshio is installed (e.g. ``pip install meshio``). If it
+is not, then the method fails with an informative RuntimeError.
+
+Simple use of the functionality could be as follows:
+
+-- code-block:: python
+  import pdal
+
+  ...
+  pl = pdal.Pipeline(pipeline)
+  pl.execute()
+
+  mesh = pl.get_meshio(0)
+  mesh.write('test.obj')
+
+Advanced Mesh Use Case
+................................................................................
+
+USE-CASE : Take a LiDAR map, create a mesh from the ground points, split into tiles and store the tiles in PostGIS.
+
+.. note:: Like ``Pipeline.arrays``, ``Pipeline.meshes`` returns a list of ``numpy.ndarray`` to provide for the case 
+where the output from a Pipeline is multiple PointViews
+
+(example using 1.2-with-color.las and not doing the ground classification for clarity)
+
+.. code_block:: python
+
+  import pdal
+  import json
+  import psycopg2
+  import io
+
+  pipe = [
+      '.../python/test/data/1.2-with-color.las',
+      {"type":  "filters.splitter", "length": 1000}, 
+      {"type":  "filters.delaunay"}
+  ]
+
+  pl = pdal.Pipeline(json.dumps(pipe))
+  pl.execute()
+
+  conn = psycopg(%CONNNECTION_STRING%)
+  buffer = io.StringIO
+
+  for idx in range(len(pl.meshes)):
+      m =  pl.get_meshio(idx)
+      if m:
+          m.write(buffer,  file_format = "wkt")
+          with conn.cursor() as curr:
+            curr.execute(
+                "INSERT INTO %table-name% (mesh) VALUES (ST_GeomFromEWKT(%(ewkt)s)", 
+                { "ewkt": buffer.getvalue()}
+            )
+
+  conn.commit()
+  conn.close()
+  buffer.close()
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -174,14 +174,14 @@ method creates a `Mesh` object from the `PointView` array and mesh properties.
 Simple use of the functionality could be as follows:
 
 .. code-block:: python
-  import pdal
+    import pdal
 
-  ...
-  pl = pdal.Pipeline(pipeline)
-  pl.execute()
+    ...
+    pl = pdal.Pipeline(pipeline)
+    pl.execute()
 
-  mesh = pl.get_meshio(0)
-  mesh.write('test.obj')
+    mesh = pl.get_meshio(0)
+    mesh.write('test.obj')
 
 Advanced Mesh Use Case
 ................................................................................
@@ -192,38 +192,38 @@ USE-CASE : Take a LiDAR map, create a mesh from the ground points, split into ti
 
 (example using 1.2-with-color.las and not doing the ground classification for clarity)
 
-.. code_block:: python
+.. code-block:: python
 
-  import pdal
-  import json
-  import psycopg2
-  import io
+    import pdal
+    import json
+    import psycopg2
+    import io
 
-  pipe = [
-      '.../python/test/data/1.2-with-color.las',
-      {"type":  "filters.splitter", "length": 1000}, 
-      {"type":  "filters.delaunay"}
-  ]
+    pipe = [
+        '.../python/test/data/1.2-with-color.las',
+        {"type":  "filters.splitter", "length": 1000}, 
+        {"type":  "filters.delaunay"}
+    ]
 
-  pl = pdal.Pipeline(json.dumps(pipe))
-  pl.execute()
+    pl = pdal.Pipeline(json.dumps(pipe))
+    pl.execute()
 
-  conn = psycopg(%CONNNECTION_STRING%)
-  buffer = io.StringIO
+    conn = psycopg(%CONNNECTION_STRING%)
+    buffer = io.StringIO
 
-  for idx in range(len(pl.meshes)):
-      m =  pl.get_meshio(idx)
-      if m:
-          m.write(buffer,  file_format = "wkt")
-          with conn.cursor() as curr:
-            curr.execute(
-                "INSERT INTO %table-name% (mesh) VALUES (ST_GeomFromEWKT(%(ewkt)s)", 
-                { "ewkt": buffer.getvalue()}
-            )
+    for idx in range(len(pl.meshes)):
+        m =  pl.get_meshio(idx)
+        if m:
+            m.write(buffer,  file_format = "wkt")
+            with conn.cursor() as curr:
+              curr.execute(
+                  "INSERT INTO %table-name% (mesh) VALUES (ST_GeomFromEWKT(%(ewkt)s)", 
+                  { "ewkt": buffer.getvalue()}
+              )
 
-  conn.commit()
-  conn.close()
-  buffer.close()
+    conn.commit()
+    conn.close()
+    buffer.close()
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -153,10 +153,12 @@ Accessing Mesh Data
 
 Some PDAL stages (for instance ``filters.delaunay``) create TIN type mesh data. 
 
-This data can be accessed in Python using the ``Pipeline.meshes`` property, which returns ``numpy.ndarray`` 
-of shape (1,n) where n is the number of Triangles in the mesh. If the PointView contains no mesh data, then n = 0.
+This data can be accessed in Python using the ``Pipeline.meshes`` property, which returns a ``numpy.ndarray`` 
+of shape (1,n) where n is the number of Triangles in the mesh. 
 
-Each Triangle is a tuple ``(A,B,C)`` where A, B and C are indicees into the PointView for the point that is the vertex for the Triangle.
+If the PointView contains no mesh data, then n = 0.
+
+Each Triangle is a tuple ``(A,B,C)`` where A, B and C are indices into the PointView identifying the point that is the vertex for the Triangle.
 
 Meshio Integration
 ................................................................................
@@ -167,12 +169,11 @@ into the `Meshio <https://github.com/nschloe/meshio>`__ library.
 The ``pdal.Pipeline`` class provides the ``get_meshio(idx: int) -> meshio.Mesh`` method. This 
 method creates a `Mesh` object from the `PointView` array and mesh properties.
 
-.. note:: The meshio integration requires that meshio is installed (e.g. ``pip install meshio``). If it
-is not, then the method fails with an informative RuntimeError.
+.. note:: The meshio integration requires that meshio is installed (e.g. ``pip install meshio``). If it is not, then the method fails with an informative RuntimeError.
 
 Simple use of the functionality could be as follows:
 
--- code-block:: python
+.. code-block:: python
   import pdal
 
   ...
@@ -187,8 +188,7 @@ Advanced Mesh Use Case
 
 USE-CASE : Take a LiDAR map, create a mesh from the ground points, split into tiles and store the tiles in PostGIS.
 
-.. note:: Like ``Pipeline.arrays``, ``Pipeline.meshes`` returns a list of ``numpy.ndarray`` to provide for the case 
-where the output from a Pipeline is multiple PointViews
+.. note:: Like ``Pipeline.arrays``, ``Pipeline.meshes`` returns a list of ``numpy.ndarray`` to provide for the case where the output from a Pipeline is multiple PointViews
 
 (example using 1.2-with-color.las and not doing the ground classification for clarity)
 

--- a/pdal/CMakeLists.txt
+++ b/pdal/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(EXTENSION_SRC
     PyArray.cpp
     PyArray.hpp
+    PyMesh.cpp
+    PyMesh.hpp
     PyDimension.hpp
     PyPipeline.cpp
     PyPipeline.hpp)

--- a/pdal/PyMesh.cpp
+++ b/pdal/PyMesh.cpp
@@ -1,0 +1,216 @@
+/******************************************************************************
+* Copyright (c) 2021, Runette Software Ltd (www.runette.co.uk)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include "PyMesh.hpp"
+
+#include <numpy/arrayobject.h>
+
+
+namespace pdal
+{
+namespace python
+{
+
+// Create new empty mesh
+//
+Mesh::Mesh() : m_mesh(nullptr)
+{
+    hasMesh = false;
+    if (_import_array() < 0)
+        throw pdal_error("Could not import numpy.core.multiarray.");
+}
+
+Mesh::~Mesh()
+{
+    if (m_mesh)
+        Py_XDECREF((PyObject *)m_mesh);
+}
+
+// Update from a PointView
+//
+void Mesh::update(PointViewPtr view)
+{
+    npy_intp size;
+
+    if (m_mesh)
+        Py_XDECREF((PyObject *)m_mesh);
+    m_mesh = nullptr;  // Just in case of an exception.
+
+    TriangularMesh* mesh = view->mesh();
+    if (mesh)
+    {
+        hasMesh = true;
+        size = mesh->size();
+    } else {
+        hasMesh = false;
+        size = 0;
+    }
+
+    PyObject *dtype_dict = (PyObject*)buildNumpyDescription(view);
+    if (!dtype_dict)
+        throw pdal_error("Unable to build numpy dtype "
+                "description dictionary");
+
+    PyArray_Descr *dtype = nullptr;
+    if (PyArray_DescrConverter(dtype_dict, &dtype) == NPY_FAIL)
+        throw pdal_error("Unable to build numpy dtype");
+    Py_XDECREF(dtype_dict);
+
+    // This is a 1 x size array.
+    m_mesh = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type, dtype,
+            1, &size, 0, nullptr, NPY_ARRAY_CARRAY, nullptr);
+
+    for (PointId idx = 0; idx < size; idx++)
+    {
+        char* p = (char *)PyArray_GETPTR1(m_mesh, idx);
+        const Triangle& t = (*mesh)[idx];
+        uint32_t a = (uint32_t)t.m_a;
+        std::memcpy(p, &a, 4);
+        uint32_t b = (uint32_t)t.m_b;
+        std::memcpy(p + 4, &b, 4);
+        uint32_t c = (uint32_t)t.m_c;
+        std::memcpy(p + 8, &c,  4);
+    }
+}
+
+
+
+PyArrayObject *Mesh::getPythonArray() const
+{
+    return m_mesh;
+}
+
+PyObject* Mesh::buildNumpyDescription(PointViewPtr view) const
+{
+    // Build up a numpy dtype dictionary
+    //
+    // {'formats': ['f8', 'f8', 'f8', 'u2', 'u1', 'u1', 'u1', 'u1', 'u1',
+    //              'f4', 'u1', 'u2', 'f8', 'u2', 'u2', 'u2'],
+    // 'names': ['X', 'Y', 'Z', 'Intensity', 'ReturnNumber',
+    //           'NumberOfReturns', 'ScanDirectionFlag', 'EdgeOfFlightLine',
+    //           'Classification', 'ScanAngleRank', 'UserData',
+    //           'PointSourceId', 'GpsTime', 'Red', 'Green', 'Blue']}
+    //
+
+    Dimension::IdList dims = view->dims();
+
+    PyObject* dict = PyDict_New();
+    PyObject* formats = PyList_New(3);
+    PyObject* titles = PyList_New(3);
+
+    PyList_SetItem(titles, 0, PyUnicode_FromString("A"));
+    PyList_SetItem(formats, 0, PyUnicode_FromString("u4"));
+    PyList_SetItem(titles, 1, PyUnicode_FromString("B"));
+    PyList_SetItem(formats, 1, PyUnicode_FromString("u4"));
+    PyList_SetItem(titles, 2, PyUnicode_FromString("C"));
+    PyList_SetItem(formats, 2, PyUnicode_FromString("u4"));
+   
+
+    PyDict_SetItemString(dict, "names", titles);
+    PyDict_SetItemString(dict, "formats", formats);
+
+    return dict;
+}
+
+bool Mesh::rowMajor() const
+{
+    return m_rowMajor;
+}
+
+Mesh::Shape Mesh::shape() const
+{
+    return m_shape;
+}
+
+
+MeshIter& Mesh::iterator()
+{
+    MeshIter *it = new MeshIter(*this);
+    m_iterators.push_back(std::unique_ptr<MeshIter>(it));
+    return *it;
+}
+
+MeshIter::MeshIter(Mesh& mesh)
+{
+    m_iter = NpyIter_New(mesh.getPythonArray(),
+        NPY_ITER_EXTERNAL_LOOP | NPY_ITER_READONLY | NPY_ITER_REFS_OK,
+        NPY_KEEPORDER, NPY_NO_CASTING, NULL);
+    if (!m_iter)
+        throw pdal_error("Unable to create numpy iterator.");
+
+    char *itererr;
+    m_iterNext = NpyIter_GetIterNext(m_iter, &itererr);
+    if (!m_iterNext)
+    {
+        NpyIter_Deallocate(m_iter);
+        throw pdal_error(std::string("Unable to create numpy iterator: ") +
+            itererr);
+    }
+    m_data = NpyIter_GetDataPtrArray(m_iter);
+    m_stride = NpyIter_GetInnerStrideArray(m_iter);
+    m_size = NpyIter_GetInnerLoopSizePtr(m_iter);
+    m_done = false;
+}
+
+MeshIter::~MeshIter()
+{
+    NpyIter_Deallocate(m_iter);
+}
+
+MeshIter& MeshIter::operator++()
+{
+    if (m_done)
+        return *this;
+
+    if (--(*m_size))
+        *m_data += *m_stride;
+    else if (!m_iterNext(m_iter))
+        m_done = true;
+    return *this;
+}
+
+MeshIter::operator bool () const
+{
+    return !m_done;
+}
+
+char * MeshIter::operator * () const
+{
+    return *m_data;
+}
+
+
+} // namespace python
+} // namespace pdal
+

--- a/pdal/PyMesh.hpp
+++ b/pdal/PyMesh.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (c) 2016, Howard Butler (howard@hobu.co)
+* Copyright (c) 2021, Runette Software Ltd (www.runette.co.uk)
 *
 * All rights reserved.
 *
@@ -13,7 +13,7 @@
 *       notice, this list of conditions and the following disclaimer in
 *       the documentation and/or other materials provided
 *       with the distribution.
-*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*     * Neither the name of Hobu, Inc. nor the
 *       names of its contributors may be used to endorse or promote
 *       products derived from this software without specific prior
 *       written permission.
@@ -34,64 +34,70 @@
 
 #pragma once
 
-#include <pdal/PipelineManager.hpp>
-#include <pdal/PipelineWriter.hpp>
-#include <pdal/util/FileUtils.hpp>
-#include <pdal/PipelineExecutor.hpp>
 
-#include <string>
-#include <sstream>
-#include <memory>
+#include <pdal/PointView.hpp>
+#include <numpy/ndarraytypes.h>
+
+#include <utility>
 
 namespace pdal
 {
 namespace python
 {
+class MeshIter;
 
-class Array;
-class Mesh;
-
-class python_error : public std::runtime_error
+class PDAL_DLL Mesh
 {
 public:
-    inline python_error(std::string const& msg) : std::runtime_error(msg)
-        {}
-};
+    using Shape = std::array<size_t, 3>;
 
-class Pipeline
-{
-public:
-    Pipeline(std::string const& json);
-    Pipeline(std::string const& json,
-        std::vector<pdal::python::Array*> arrays);
-    ~Pipeline();
+    bool hasMesh;
 
-    int64_t execute();
-    bool validate();
-    inline std::string getPipeline() const
-    {
-        return m_executor->getPipeline();
-    }
-    inline std::string getMetadata() const
-    {
-        return m_executor->getMetadata();
-    }
-    inline std::string getSchema() const
-    {
-        return m_executor->getSchema();
-    }
-    inline std::string getLog() const
-    {
-        return m_executor->getLog();
-    }
-    std::vector<pdal::python::Array *> getArrays() const;
-    std::vector<pdal::python::Mesh *> getMeshes() const;
-    void setLogLevel(int level);
-    int getLogLevel() const;
+    Mesh();
+
+    ~Mesh();
+
+    void update(PointViewPtr view);
+    PyArrayObject *getPythonArray() const;
+
+    bool rowMajor() const;
+    Shape shape() const;
+    MeshIter& iterator();
+
 
 private:
-    std::shared_ptr<pdal::PipelineExecutor> m_executor;
+    inline PyObject* buildNumpyDescription(PointViewPtr view) const;
+
+    PyArrayObject* m_mesh;
+
+    Mesh& operator=(Mesh const& rhs);
+    bool m_rowMajor;
+    Shape m_shape {};
+    std::vector<std::unique_ptr<MeshIter>> m_iterators;
 };
+
+class MeshIter
+{
+public:
+    MeshIter(const MeshIter&) = delete;
+    MeshIter() = delete;
+
+    MeshIter(Mesh& mesh);
+    ~MeshIter();
+
+    MeshIter& operator++();
+    operator bool () const;
+    char *operator * () const;
+
+private:
+    NpyIter *m_iter;
+    NpyIter_IterNextFunc *m_iterNext;
+    char **m_data;
+    npy_intp *m_size;
+    npy_intp *m_stride;
+    bool m_done;
+};    
 
 } // namespace python
 } // namespace pdal
+

--- a/pdal/PyPipeline.cpp
+++ b/pdal/PyPipeline.cpp
@@ -45,6 +45,7 @@
 #include <pdal/pdal_features.hpp>
 
 #include "PyArray.hpp"
+#include "PyMesh.hpp"
 
 namespace pdal
 {
@@ -165,6 +166,24 @@ std::vector<Array *> Pipeline::getArrays() const
         Array *array = new python::Array;
         array->update(i);
         output.push_back(array);
+    }
+    return output;
+}
+
+std::vector<Mesh *> Pipeline::getMeshes() const
+{
+    std::vector<Mesh *> output;
+
+    if (!m_executor->executed())
+        throw python_error("call execute() before fetching the mesh");
+
+    const PointViewSet& pvset = m_executor->getManagerConst().views();
+
+    for (auto i: pvset)
+    {
+        Mesh *mesh = new python::Mesh;
+        mesh->update(i);
+        output.push_back(mesh);
     }
     return output;
 }

--- a/pdal/libpdalpython.pyx
+++ b/pdal/libpdalpython.pyx
@@ -41,6 +41,11 @@ cdef extern from "PyArray.hpp" namespace "pdal::python":
         Array(np.ndarray) except +
         void *getPythonArray() except+
 
+cdef extern from "PyMesh.hpp" namespace "pdal::python":
+    cdef cppclass Mesh:
+        Mesh(np.ndarray) except +
+        void *getPythonArray() except +
+
 cdef extern from "PyPipeline.hpp" namespace "pdal::python":
     cdef cppclass Pipeline:
         Pipeline(const char* ) except +
@@ -52,6 +57,7 @@ cdef extern from "PyPipeline.hpp" namespace "pdal::python":
         string getSchema() except +
         string getLog() except +
         vector[Array*] getArrays() except +
+        vector[Mesh*] getMeshes() except +
         int getLogLevel()
         void setLogLevel(int)
 
@@ -152,6 +158,21 @@ cdef class PyPipeline:
                 inc(it)
             return output
 
+    property meshes:
+
+        def __get__(self):
+            v = self.thisptr.getMeshes()
+            output = []
+            cdef vector[Mesh *].iterator it = v.begin()
+            cdef Mesh* m
+            while it != v.end():
+                ptr = deref(it)
+                m = ptr#.get()
+                o = m.getPythonArray()
+                output.append(<object>o)
+                del ptr
+                inc(it)
+            return output
 
     def execute(self):
         if not self.thisptr:

--- a/pdal/pipeline.py
+++ b/pdal/pipeline.py
@@ -45,3 +45,26 @@ class Pipeline(object):
     def get_arrays(self):
         return self.p.arrays
     arrays = property(get_arrays)
+
+    def get_meshes(self):
+        return self.p.meshes
+    meshes = property(get_meshes)
+
+    def get_meshio(self, idx: int):
+        try:
+            from meshio import Mesh
+        except ModuleNotFoundError:
+            raise RuntimeError(
+                "The get_meshio function can only be used if you have installed meshio. Try pip install meshio")
+        array = self.arrays[idx]
+        mesh = self.meshes[idx]
+        if len(mesh) == 0:
+            return None
+        return Mesh(
+            np.stack((array['X'], array['Y'], array['Z']), 1),
+            [(
+                "triangle",
+                np.stack((mesh['A'], mesh['B'], mesh['C']), 1)
+            )
+            ]
+        )

--- a/test/data/mesh.json
+++ b/test/data/mesh.json
@@ -1,0 +1,5 @@
+[
+    "test/data/1.2-with-color.las",
+    {"type":  "filters.splitter", "length": 1000}, 
+    {"type":  "filters.delaunay"}
+]

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -231,6 +231,33 @@ class TestDimensions(PDALTest):
         self.assertLess(len(dims), 100)
         self.assertGreater(len(dims), 71)
 
+class TestMesh(PDALTest):
+    @unittest.skipUnless(os.path.exists(os.path.join(DATADIRECTORY, 'sort.json')),
+                         "missing test data")
+    def test_no_execute(self):
+        """Does fetching meshes without executing throw an exception"""
+        json = self.fetch_json('sort.json')
+        r = pdal.Pipeline(json)
+        with self.assertRaises(RuntimeError):
+            r.meshes
+
+    @unittest.skipUnless(os.path.exists(os.path.join(DATADIRECTORY, 'mesh.json')),
+                         "missing test data")
+    def test_mesh(self):
+        """Can we fetch PDAL face data as a numpy array"""
+        json = self.fetch_json('mesh.json')
+        r = pdal.Pipeline(json)
+        r.validate()
+        points = r.execute()
+        self.assertEqual(points, 1065)  
+        meshes = r.meshes
+        self.assertEqual(len(meshes), 24)
+
+        m = meshes[0]
+        self.assertEqual(m.dtype, "dtype([('A', '<u4'), ('B', '<u4'), ('C', '<u4')])")
+        self.assertEqual(len(m),134)
+        self.assertEqual(m[0][0], 29)
+
 def test_suite():
     return unittest.TestSuite(
         [TestPipeline()])

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -254,7 +254,7 @@ class TestMesh(PDALTest):
         self.assertEqual(len(meshes), 24)
 
         m = meshes[0]
-        self.assertEqual(m.dtype, "dtype([('A', '<u4'), ('B', '<u4'), ('C', '<u4')])")
+        self.assertEqual(str(m.dtype), "[('A', '<u4'), ('B', '<u4'), ('C', '<u4')]")
         self.assertEqual(len(m),134)
         self.assertEqual(m[0][0], 29)
 


### PR DESCRIPTION
Adds the ability to access face data from meshes in the Python API:

- Adds a new method to `pdal.Pipeline` called `get_meshes()` that returns a list of `ndarray` in the same format as `get_arrays()`. Each `ndarray` represents one mesh from one `PointView`and is a (1, size) array of Triangles, where each triangle is a tuple of `(index of corner a, index of corner b, index of corner c)` - the index referring to the points in `PointView` array.
- Adds the details to `libpdalpython.pyx` to implement the above,
- Adds a method to the cpp `Pipeline` class called `getMeshes()` that returns a vector of PyMesh
- Adds a cpp class `PyMesh` very much a copy of the `PyArray` class, in this case the class creates the mesh ndarray.

All of the above is working on my builds and does not introduce any new dependencies. However, I also wanted to create a way to create a useable Mesh object easily.

NOTE - where there is no mesh attached to the `PointView`, `get_meshes` will return an ndarray with 0 rows to ensure that the correspondence between arrays and meshes can be retained.

One good way of doing that is using [the Meshio package](https://github.com/nschloe/meshio) - which allows the Mesh object to be re-used by a wide range of other packages.

So - I have also included the following :

- Adds a new method to `pdal.Pipeline` called `get_meshio(idx: int) -> meshio.Mesh`. This uses `get_meshes` and `get_arrays` to create a Mesh object. At the moment it does not add the non-geometry data (a ToDo). This method requires `meshio` and if it is not installed will fail with an informative error.

# Usage

The simplest usage would look like the following: 

```python
import pdal

...
pl = pdal.Pipeline(pipeline)
pl.execute()

mesh = pl.get_meshio(0)
mesh.write('test.obj')

```

NOTE that since we are getting back a vector of meshes - we can do something that was not easy before and was actually the use-case that I needed to solve:

USE-CASE : Take a LiDAR map, create a mesh from the ground points, split into tiles and store the tiles in PostGIS.

(example using 1.2-with-color.las and not doing the ground classification for clarity)

```python
import pdal
import json
import psycopg2
import io

pipe = [
     '.../python/test/data/1.2-with-color.las',
     {"type":  "filters.splitter", "length": 1000}, 
     {"type":  "filters.delaunay"}
]

pl = pdal.Pipeline(json.dumps(pipe))
pl.execute()

conn = psycopg(%CONNNECTION_STRING%)
buffer = io.StringIO

for idx in range(len(pl.meshes)):
    m =  pl.get_meshio(idx)
    if m:
        m.write(buffer,  file_format = "wkt")
        with conn.cursor() as curr:
           curr.execute(
               "INSERT INTO %table-name% (mesh) VALUES (ST_GeomFromEWKT(%(ewkt)s)", 
               { "ewkt": buffer.getvalue()}
           )

conn.commit()
conn.close()
buffer.close()
```
This creates 24 tile meshes in PostGIS