### PR TITLE
Pipeline iterator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,17 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'macos-latest' ]
-        python-version: ['3.7','3.8', '3.9']
+        python-version: ['3.8']
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Download the conda PDAL artifact
+      shell: bash -l {0}
+      run: |
+        wget https://nightly.link/TileDB-Inc/PDAL/suites/3952223638/artifacts/${{ matrix.os == 'ubuntu-latest' && '99212479' || '99212478' }} -O pdal.zip
+        unzip pdal.zip -d local
+
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
@@ -38,7 +45,7 @@ jobs:
 
     - name: Dependencies
       shell: bash -l {0}
-      run: mamba install --yes --quiet -c conda-forge scikit-build numpy python=${{ matrix.python-version }} cython pdal pytest
+      run: mamba install --yes --quiet -c ./local -c conda-forge scikit-build numpy python=${{ matrix.python-version }} cython pdal pytest
 
     - name: Install
       shell: bash -l {0}
@@ -65,7 +72,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['windows-latest']
-        python-version: ['3.7','3.8', '3.9']
+        python-version: ['3.8']
 
     steps:
     - uses: actions/checkout@v2
@@ -74,11 +81,19 @@ jobs:
         channels: conda-forge
         python-version: ${{ matrix.python-version }}
 
+    - uses: suisei-cn/actions-download-file@v1
+      id: download_artifact
+      name: Download the conda PDAL Windows artifact
+      with:
+        url: "https://nightly.link/TileDB-Inc/PDAL/suites/3952223638/artifacts/99212480"
+        target: .
+
     - name: Dependencies
       shell: cmd /C CALL "{0}"
       run: |
         call conda activate test
-        conda install --yes --quiet -c conda-forge scikit-build numpy python=${{ matrix.python-version }} cython pdal pytest
+        7z x ${{ steps.download_artifact.outputs.filename }} -olocal
+        conda install --yes --quiet -c ./local -c conda-forge scikit-build numpy python=${{ matrix.python-version }} cython pdal pytest
 
     - name: Install
       shell: cmd /C CALL "{0}"
@@ -113,6 +128,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Download the conda PDAL artifact
+      shell: bash -l {0}
+      run: |
+        wget https://nightly.link/TileDB-Inc/PDAL/suites/3952223638/artifacts/99212479 -O pdal.zip
+        unzip pdal.zip -d local
+
     - uses: conda-incubator/setup-miniconda@v2
       with:
         channels: conda-forge
@@ -121,7 +143,7 @@ jobs:
 
     - name: Dependencies
       shell: bash -l {0}
-      run: mamba install --yes --quiet -c conda-forge scikit-build numpy python=${{ matrix.python-version }} cython pdal pytest
+      run: mamba install --yes --quiet -c ./local -c conda-forge scikit-build numpy python=${{ matrix.python-version }} cython pdal pytest
 
     - name: sdist
       shell: bash -l {0}

--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,34 @@ PDAL and Python:
     print (count)
 
 
+Iterator API
+................................................................................
+For streamable pipelines (pipelines that consist exclusively of streamable PDAL
+stages), an iterator API is available via ``pdal.PipelineIterator``. Iterating
+over a ``PipelineIterator`` executes the pipeline in streaming mode and yields
+Numpy arrays of length up to ``chunk_size`` (default=10000).
+
+.. code-block:: python
+
+
+    json = """
+    [
+      "test/data/autzen-utm.las",
+      {
+        "type": "filters.range",
+        "limits": "Intensity[80:120)"
+      }
+    ]
+    """
+
+    import pdal
+    pipeline = pdal.PipelineIterator(json, chunk_size=500)
+    for array in pipeline:
+        print(len(array))
+    # or to concatenate all arrays into one
+    # full_array = np.concatenate(list(pipeline))
+
+
 Accessing Mesh Data
 ................................................................................
 

--- a/pdal/PyPipeline.cpp
+++ b/pdal/PyPipeline.cpp
@@ -50,13 +50,6 @@ namespace python
 {
 
 
-void readPipeline(PipelineExecutor* executor, std::string json)
-{
-    std::stringstream strm(json);
-    executor->getManager().readPipeline(strm);
-}
-
-
 void addArrayReaders(PipelineExecutor* executor, std::vector<Array*> arrays)
 {
     // Make the symbols in pdal_base global so that they're accessible
@@ -177,14 +170,6 @@ PyArrayObject* viewToNumpyArray(PointViewPtr view)
     return array;
 }
 
-std::vector<PyArrayObject*> getArrays(const PipelineExecutor* executor)
-{
-    std::vector<PyArrayObject*> output;
-    for (auto view: executor->getManagerConst().views())
-        output.push_back(viewToNumpyArray(view));
-    return output;
-}
-
 
 PyArrayObject* meshToNumpyArray(const TriangularMesh* mesh)
 {
@@ -237,14 +222,6 @@ PyArrayObject* meshToNumpyArray(const TriangularMesh* mesh)
     return array;
 }
 
-
-std::vector<PyArrayObject*> getMeshes(const PipelineExecutor* executor)
-{
-    std::vector<PyArrayObject*> output;
-    for (auto view: executor->getManagerConst().views())
-        output.push_back(meshToNumpyArray(view->mesh()));
-    return output;
-}
 
 } // namespace python
 } // namespace pdal

--- a/pdal/PyPipeline.hpp
+++ b/pdal/PyPipeline.hpp
@@ -45,12 +45,9 @@ namespace python
 
 class Array;
 
-void readPipeline(PipelineExecutor* executor, std::string json);
 void addArrayReaders(PipelineExecutor* executor, std::vector<Array*> arrays);
 PyArrayObject* viewToNumpyArray(PointViewPtr view);
 PyArrayObject* meshToNumpyArray(const TriangularMesh* mesh);
-std::vector<PyArrayObject*> getArrays(const PipelineExecutor* executor);
-std::vector<PyArrayObject*> getMeshes(const PipelineExecutor* executor);
 
 } // namespace python
 } // namespace pdal

--- a/pdal/__init__.py
+++ b/pdal/__init__.py
@@ -1,4 +1,4 @@
-from .libpdalpython import Pipeline
+from .libpdalpython import Pipeline, PipelineIterator
 from .libpdalpython import getDimensions, getInfo
 
 __version__ = "2.4.2"

--- a/test/data/range.json
+++ b/test/data/range.json
@@ -1,0 +1,7 @@
+[
+  "test/data/autzen-utm.las",
+  {
+    "type": "filters.range",
+    "limits": "Intensity[80:120)"
+  }
+]


### PR DESCRIPTION
Adds `PipelineIterator` for executing a streamable PDAL pipeline in streaming mode. `PipelineIterator` is a Python iterator that yields Numpy arrays of bounded length configurable by `chunk_size` (default=10000).

This PR is built on top of https://github.com/PDAL/python/pull/89; the relevant `PipelineIterator` changes are contained in a [single commit](https://github.com/PDAL/python/pull/90/commits/b756da7bd0bbad06e8e608ad57b481d4e1fb473a). There is also a [temporary commit](https://github.com/PDAL/python/pull/90/commits/d6569c80a10cb53a44f6f76041ef446ed7cd04db) (not to be merged) for running the CI against a [custom PDAL build](https://github.com/TileDB-Inc/PDAL/actions/runs/1304288661) of the related [core PDAL PR](https://github.com/PDAL/PDAL/pull/3557) (Python 3.8 only).