### PR TITLE
Pipeline iterator - parallelized version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,7 @@ PDAL and Python:
     ).pipeline(clamped)
     print(pipeline.execute())  # 387 points
 
-Iterating Streamable Pipelines
+Executing Streamable Pipelines
 ................................................................................
 Streamable pipelines (pipelines that consist exclusively of streamable PDAL
 stages) can be executed in streaming mode via ``Pipeline.iterator()``. This
@@ -206,6 +206,12 @@ returns an iterator object that yields Numpy arrays of up to ``chunk_size`` size
 ``Pipeline.iterator()`` also takes an optional ``prefetch`` parameter (default=0)
 to allow prefetching up to to this number of arrays in parallel and buffering
 them until they are yielded to the caller.
+
+If you just want to execute a streamable pipeline in streaming mode and don't
+need to access the data points (typically when the pipeline has Writer stage(s)),
+you can use the ``Pipeline.execute_streaming(chunk_size)`` method instead. This
+is functionally equivalent to ``sum(map(len, pipeline.iterator(chunk_size)))``
+but more efficient as it avoids allocating and filling any arrays in memory.
 
 Accessing Mesh Data
 ................................................................................

--- a/README.rst
+++ b/README.rst
@@ -187,6 +187,25 @@ PDAL and Python:
     ).pipeline(clamped)
     print(pipeline.execute())  # 387 points
 
+Iterating Streamable Pipelines
+................................................................................
+Streamable pipelines (pipelines that consist exclusively of streamable PDAL
+stages) can be executed in streaming mode via ``Pipeline.iterator()``. This
+returns an iterator object that yields Numpy arrays of up to ``chunk_size`` size
+(default=10000) at a time.
+
+.. code-block:: python
+
+    import pdal
+    pipeline = pdal.Reader("test/data/autzen-utm.las") | pdal.Filter.range(limits="Intensity[80:120)")
+    for array in pipeline.iterator(chunk_size=500):
+        print(len(array))
+    # or to concatenate all arrays into one
+    # full_array = np.concatenate(list(pipeline))
+
+``Pipeline.iterator()`` also takes an optional ``prefetch`` parameter (default=0)
+to allow prefetching up to to this number of arrays in parallel and buffering
+them until they are yielded to the caller.
 
 Accessing Mesh Data
 ................................................................................
@@ -236,17 +255,14 @@ USE-CASE : Take a LiDAR map, create a mesh from the ground points, split into ti
 .. code-block:: python
 
     import pdal
-    import json
     import psycopg2
     import io
 
-    pipe = [
-        '.../python/test/data/1.2-with-color.las',
-        {"type":  "filters.splitter", "length": 1000}, 
-        {"type":  "filters.delaunay"}
-    ]
-
-    pl = pdal.Pipeline(json.dumps(pipe))
+    pl = (
+        pdal.Reader(".../python/test/data/1.2-with-color.las")
+        | pdal.Filter.splitter(length=1000)
+        | pdal.Filter.delaunay()
+    )
     pl.execute()
 
     conn = psycopg(%CONNNECTION_STRING%)

--- a/pdal/CMakeLists.txt
+++ b/pdal/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(EXTENSION_SRC PyArray.cpp PyPipeline.cpp)
+set(EXTENSION_SRC PyArray.cpp PyPipeline.cpp StreamableExecutor.cpp)
 
 set(extension "libpdalpython")
 add_cython_target(${extension} "libpdalpython.pyx" CXX PY3)

--- a/pdal/PyPipeline.cpp
+++ b/pdal/PyPipeline.cpp
@@ -44,6 +44,16 @@ namespace pdal
 namespace python
 {
 
+
+void CountPointTable::reset()
+{
+    for (PointId idx = 0; idx < numPoints(); idx++)
+        if (!skip(idx))
+            m_count++;
+    FixedPointTable::reset();
+}
+
+
 PipelineExecutor::PipelineExecutor(
     std::string const& json, std::vector<std::shared_ptr<Array>> arrays, int level)
 {
@@ -69,6 +79,14 @@ point_count_t PipelineExecutor::execute()
     return count;
 }
 
+
+point_count_t PipelineExecutor::executeStream(point_count_t streamLimit)
+{
+    CountPointTable table(streamLimit);
+    m_manager.executeStream(table);
+    m_executed = true;
+    return table.count();
+}
 
 const PointViewSet& PipelineExecutor::views() const
 {

--- a/pdal/PyPipeline.cpp
+++ b/pdal/PyPipeline.cpp
@@ -50,13 +50,6 @@ namespace python
 {
 
 
-void readPipeline(PipelineExecutor* executor, std::string json)
-{
-    std::stringstream strm(json);
-    executor->getManager().readPipeline(strm);
-}
-
-
 void addArrayReaders(PipelineExecutor* executor, std::vector<std::shared_ptr<Array>> arrays)
 {
     // Make the symbols in pdal_base global so that they're accessible

--- a/pdal/PyPipeline.cpp
+++ b/pdal/PyPipeline.cpp
@@ -39,18 +39,82 @@
 #include <dlfcn.h>
 #endif
 
-#include <Python.h>
-
-#include <pdal/Stage.hpp>
-#include <pdal/pdal_features.hpp>
-
 namespace pdal
 {
 namespace python
 {
 
+PipelineExecutor::PipelineExecutor(
+    std::string const& json, std::vector<std::shared_ptr<Array>> arrays, int level)
+{
+    if (level < 0 || level > 8)
+        throw pdal_error("log level must be between 0 and 8!");
 
-void addArrayReaders(PipelineExecutor* executor, std::vector<std::shared_ptr<Array>> arrays)
+    LogPtr log(Log::makeLog("pypipeline", &m_logStream));
+    log->setLevel(static_cast<pdal::LogLevel>(level));
+    m_manager.setLog(log);
+
+    std::stringstream strm;
+    strm << json;
+    m_manager.readPipeline(strm);
+
+    addArrayReaders(arrays);
+}
+
+
+point_count_t PipelineExecutor::execute()
+{
+    point_count_t count = m_manager.execute();
+    m_executed = true;
+    return count;
+}
+
+
+const PointViewSet& PipelineExecutor::views() const
+{
+    if (!m_executed)
+        throw pdal_error("Pipeline has not been executed!");
+
+    return m_manager.views();
+}
+
+
+std::string PipelineExecutor::getPipeline() const
+{
+    if (!m_executed)
+        throw pdal_error("Pipeline has not been executed!");
+
+    std::stringstream strm;
+    pdal::PipelineWriter::writePipeline(m_manager.getStage(), strm);
+    return strm.str();
+}
+
+
+std::string PipelineExecutor::getMetadata() const
+{
+    if (!m_executed)
+        throw pdal_error("Pipeline has not been executed!");
+
+    std::stringstream strm;
+    MetadataNode root = m_manager.getMetadata().clone("metadata");
+    pdal::Utils::toJSON(root, strm);
+    return strm.str();
+}
+
+
+std::string PipelineExecutor::getSchema() const
+{
+    if (!m_executed)
+        throw pdal_error("Pipeline has not been executed!");
+
+    std::stringstream strm;
+    MetadataNode root = pointTable().layout()->toMetadata().clone("schema");
+    pdal::Utils::toJSON(root, strm);
+    return strm.str();
+}
+
+
+void PipelineExecutor::addArrayReaders(std::vector<std::shared_ptr<Array>> arrays)
 {
     // Make the symbols in pdal_base global so that they're accessible
     // to PDAL plugins.  Python dlopen's this extension with RTLD_LOCAL,
@@ -65,8 +129,7 @@ void addArrayReaders(PipelineExecutor* executor, std::vector<std::shared_ptr<Arr
     if (arrays.empty())
         return;
 
-    PipelineManager& manager = executor->getManager();
-    std::vector<Stage *> roots = manager.roots();
+    std::vector<Stage *> roots = m_manager.roots();
     if (roots.size() != 1)
         throw pdal_error("Filter pipeline must contain a single root stage.");
 
@@ -81,7 +144,7 @@ void addArrayReaders(PipelineExecutor* executor, std::vector<std::shared_ptr<Arr
             MemoryViewReader::Order::ColumnMajor);
         options.add("shape", MemoryViewReader::Shape(array->shape()));
 
-        Stage& s = manager.makeReader("", "readers.memoryview", options);
+        Stage& s = m_manager.makeReader("", "readers.memoryview", options);
         MemoryViewReader& r = dynamic_cast<MemoryViewReader &>(s);
         for (auto f : array->fields())
             r.pushField(f);
@@ -101,7 +164,7 @@ void addArrayReaders(PipelineExecutor* executor, std::vector<std::shared_ptr<Arr
         roots[0]->setInput(r);
     }
 
-    manager.validateStageOptions();
+    m_manager.validateStageOptions();
 }
 
 

--- a/pdal/PyPipeline.hpp
+++ b/pdal/PyPipeline.hpp
@@ -45,7 +45,6 @@ namespace python
 
 class Array;
 
-void readPipeline(PipelineExecutor* executor, std::string json);
 void addArrayReaders(PipelineExecutor* executor, std::vector<std::shared_ptr<Array>> arrays);
 PyArrayObject* viewToNumpyArray(PointViewPtr view);
 PyArrayObject* meshToNumpyArray(const TriangularMesh* mesh);

--- a/pdal/PyPipeline.hpp
+++ b/pdal/PyPipeline.hpp
@@ -34,8 +34,7 @@
 
 #pragma once
 
-#include <pdal/PipelineExecutor.hpp>
-
+#include <pdal/PipelineManager.hpp>
 #include <numpy/arrayobject.h>
 
 namespace pdal
@@ -43,12 +42,37 @@ namespace pdal
 namespace python
 {
 
-class Array;
-
 PyObject* buildNumpyDescriptor(PointLayoutPtr layout);
-void addArrayReaders(PipelineExecutor* executor, std::vector<std::shared_ptr<Array>> arrays);
 PyArrayObject* viewToNumpyArray(PointViewPtr view);
 PyArrayObject* meshToNumpyArray(const TriangularMesh* mesh);
+
+class Array;
+
+class PDAL_DLL PipelineExecutor {
+public:
+    PipelineExecutor(std::string const& json, std::vector<std::shared_ptr<Array>> arrays, int level);
+    virtual ~PipelineExecutor() = default;
+
+    point_count_t execute();
+
+    bool executed() const { return m_executed; }
+    const PointViewSet& views() const;
+    std::string getPipeline() const;
+    std::string getMetadata() const;
+    std::string getSchema() const;
+    std::string getLog() const { return m_logStream.str(); }
+
+protected:
+    virtual ConstPointTableRef pointTable() const { return m_manager.pointTable(); }
+
+    pdal::PipelineManager m_manager;
+    bool m_executed = false;
+
+private:
+    void addArrayReaders(std::vector<std::shared_ptr<Array>> arrays);
+
+    std::stringstream m_logStream;
+};
 
 } // namespace python
 } // namespace pdal

--- a/pdal/PyPipeline.hpp
+++ b/pdal/PyPipeline.hpp
@@ -55,7 +55,6 @@ public:
 
     point_count_t execute();
 
-    bool executed() const { return m_executed; }
     const PointViewSet& views() const;
     std::string getPipeline() const;
     std::string getMetadata() const;

--- a/pdal/PyPipeline.hpp
+++ b/pdal/PyPipeline.hpp
@@ -45,6 +45,7 @@ namespace python
 
 class Array;
 
+PyObject* buildNumpyDescriptor(PointLayoutPtr layout);
 void addArrayReaders(PipelineExecutor* executor, std::vector<std::shared_ptr<Array>> arrays);
 PyArrayObject* viewToNumpyArray(PointViewPtr view);
 PyArrayObject* meshToNumpyArray(const TriangularMesh* mesh);

--- a/pdal/PyPipeline.hpp
+++ b/pdal/PyPipeline.hpp
@@ -54,6 +54,7 @@ public:
     virtual ~PipelineExecutor() = default;
 
     point_count_t execute();
+    point_count_t executeStream(point_count_t streamLimit);
 
     const PointViewSet& views() const;
     std::string getPipeline() const;
@@ -71,6 +72,19 @@ private:
     void addArrayReaders(std::vector<std::shared_ptr<Array>> arrays);
 
     std::stringstream m_logStream;
+};
+
+class CountPointTable : public FixedPointTable
+{
+public:
+    CountPointTable(point_count_t capacity) : FixedPointTable(capacity), m_count(0) {}
+    point_count_t count() const { return m_count; }
+
+protected:
+    virtual void reset();
+
+private:
+    point_count_t m_count;
 };
 
 } // namespace python

--- a/pdal/StreamableExecutor.cpp
+++ b/pdal/StreamableExecutor.cpp
@@ -186,9 +186,7 @@ StreamableExecutor::StreamableExecutor(std::string const& json, point_count_t ch
 
 StreamableExecutor::~StreamableExecutor()
 {
-    //ABELL - Hmmm.
-    if (m_thread)
-        m_thread->join();
+    stop();
 }
 
 PyArrayObject *StreamableExecutor::executeNext()

--- a/pdal/StreamableExecutor.cpp
+++ b/pdal/StreamableExecutor.cpp
@@ -104,6 +104,7 @@ void PythonPointTable::py_resizeArray(point_count_t np)
             {
                 PyObject* src_item = PyArray_GETITEM(m_curArray, PyArray_GETPTR1(m_curArray, src_idx));
                 PyArray_SETITEM(m_curArray, PyArray_GETPTR1(m_curArray, dest_idx), src_item);
+                Py_XDECREF(src_item);
             }
             dest_idx++;
         }

--- a/pdal/StreamableExecutor.cpp
+++ b/pdal/StreamableExecutor.cpp
@@ -206,8 +206,10 @@ StreamableExecutor::~StreamableExecutor()
     if (!m_executed)
     {
         m_table.disable();
+        auto gil = PyGILState_Ensure();
         while (PyArrayObject* arr = m_table.fetchArray())
             Py_XDECREF(arr);
+        PyGILState_Release(gil);
     }
     Py_BEGIN_ALLOW_THREADS
     m_thread->join();

--- a/pdal/StreamableExecutor.cpp
+++ b/pdal/StreamableExecutor.cpp
@@ -1,0 +1,308 @@
+/******************************************************************************
+* Copyright (c) 2016, Howard Butler (howard@hobu.co)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include "StreamableExecutor.hpp"
+
+#include <Python.h>
+#include <numpy/arrayobject.h>
+
+#include <pdal/Stage.hpp>
+#include <pdal/pdal_features.hpp>
+
+namespace pdal
+{
+namespace python
+{
+
+// PythonPointTable
+
+PythonPointTable::PythonPointTable(point_count_t limit, int prefetch) :
+    StreamPointTable(m_layout, limit), m_limit(limit), m_prefetch(prefetch),
+    m_curArray(nullptr), m_dtype(nullptr)
+{}
+
+PythonPointTable::~PythonPointTable()
+{
+    py_destroy();
+}
+
+void PythonPointTable::finalize()
+{
+    BasePointTable::finalize();
+    py_createDescriptor();
+    m_curArray = py_createArray();
+}
+
+void PythonPointTable::py_destroy()
+{
+    auto gil = PyGILState_Ensure();
+
+    Py_XDECREF(m_dtype);
+    Py_XDECREF(m_curArray);
+
+    PyGILState_Release(gil);
+}
+
+PyArrayObject *PythonPointTable::py_createArray() const
+{
+    auto gil = PyGILState_Ensure();
+
+    npy_intp size = (npy_intp)m_limit;
+    Py_INCREF(m_dtype);
+    PyArrayObject *arr = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type, m_dtype,
+        1, &size, 0, nullptr, NPY_ARRAY_CARRAY, nullptr);
+
+    PyGILState_Release(gil);
+    return arr;
+}
+
+void PythonPointTable::py_createDescriptor()
+{
+    auto gil = PyGILState_Ensure();
+
+    if (_import_array() < 0)
+        std::cerr << "Could not import array!\n";
+    PyObject *dtype_dict = py_buildNumpyDescriptor();
+    if (PyArray_DescrConverter(dtype_dict, &m_dtype) == NPY_FAIL)
+        m_dtype = nullptr;
+    Py_XDECREF(dtype_dict);
+
+    PyGILState_Release(gil);
+}
+
+void PythonPointTable::py_resizeArray(int np)
+{
+    npy_intp sizes[1];
+    sizes[0] = np;
+    PyArray_Dims dims{ sizes, 1 };
+
+    auto gil = PyGILState_Ensure();
+    PyArray_Resize(m_curArray, &dims, true, NPY_CORDER);
+    PyGILState_Release(gil);
+}
+
+PyObject *PythonPointTable::py_buildNumpyDescriptor() const
+{
+    // Build up a numpy dtype dictionary
+    //
+    // {'formats': ['f8', 'f8', 'f8', 'u2', 'u1', 'u1', 'u1', 'u1', 'u1',
+    //              'f4', 'u1', 'u2', 'f8', 'u2', 'u2', 'u2'],
+    // 'names': ['X', 'Y', 'Z', 'Intensity', 'ReturnNumber',
+    //           'NumberOfReturns', 'ScanDirectionFlag', 'EdgeOfFlightLine',
+    //           'Classification', 'ScanAngleRank', 'UserData',
+    //           'PointSourceId', 'GpsTime', 'Red', 'Green', 'Blue']}
+    //
+
+    DimTypeList dims = layout()->dimTypes();
+    PyObject* names = PyList_New(dims.size());
+    PyObject* formats = PyList_New(dims.size());
+    for (size_t i = 0; i < dims.size(); ++i)
+    {
+        DimType& dt = dims[i];
+        std::string name = m_layout.dimName(dt.m_id);
+        npy_intp stride = Dimension::size(dt.m_type);
+
+        std::string kind;
+        Dimension::BaseType b = Dimension::base(dt.m_type);
+        if (b == Dimension::BaseType::Unsigned)
+            kind = "u";
+        else if (b == Dimension::BaseType::Signed)
+            kind = "i";
+        else if (b == Dimension::BaseType::Floating)
+            kind = "f";
+        else
+            throw pdal_error("Unable to map kind '" + kind  +
+                "' to PDAL dimension type");
+
+        std::string type = kind + std::to_string(stride);
+        PyList_SetItem(names, i, PyUnicode_FromString(name.c_str()));
+        PyList_SetItem(formats, i, PyUnicode_FromString(type.c_str()));
+    }
+
+    PyObject* dict = PyDict_New();
+    PyDict_SetItemString(dict, "names", names);
+    PyDict_SetItemString(dict, "formats", formats);
+    return dict;
+}
+
+void PythonPointTable::reset()
+{
+    point_count_t np = numPoints();
+
+    // If this is the last chunk, the size might be less than what's expected, so
+    // resize the array to match its true size.
+    // ABELL - This isn't quite right. We want to know if there are any skips and deal with those
+    // but I'm leaving that for the moment.
+    if (np && np != m_limit)
+        py_resizeArray(np);
+
+    // This will keep putting arrays on the list until done, whether or not the consumer
+    // can handle them that fast. We can modify as appropriate to block if desired.
+    std::unique_lock<std::mutex> l(m_mutex);
+    {
+        // It's possible that this is called with 0 points processed, in which case
+        // we don't push the current array.
+        if (np)
+        {
+            m_arrays.push(m_curArray);
+            m_curArray = nullptr;
+        }
+
+        bool done = np < m_limit;
+
+        // If we just pushed the last chunk, push a nullptr so that a reader knows.
+        if (done)
+            m_arrays.push(nullptr);
+        m_producedCv.notify_one();
+
+        if (done)
+            return;
+
+        while (m_arrays.size() > m_prefetch)
+            m_consumedCv.wait(l);
+    }
+
+    // Make a new array for data.
+    m_curArray = py_createArray();
+}
+
+PyArrayObject *PythonPointTable::fetchArray()
+{
+    PyArrayObject *arr = nullptr;
+
+    // Lock scope.
+    Py_BEGIN_ALLOW_THREADS
+    {
+        std::unique_lock<std::mutex> l(m_mutex);
+        while (m_arrays.empty())
+            m_producedCv.wait(l);
+
+        // Grab the array from the front of the list and notify that we did so.
+        arr = m_arrays.front();
+        m_arrays.pop();
+    }
+    Py_END_ALLOW_THREADS
+    // Notify that we consumed an array.
+    m_consumedCv.notify_one();
+    return arr;
+}
+
+char *PythonPointTable::getPoint(PointId idx)
+{
+    return (char *)PyArray_GETPTR1(m_curArray, (npy_intp)idx);
+}
+
+
+// StreamableExecutor
+
+StreamableExecutor::StreamableExecutor(const char *json, int chunkSize, int prefetch) :
+    m_json(json), m_table(chunkSize, prefetch), m_manager(chunkSize),
+    m_log(Log::makeLog("pdal_python", &m_logStream))
+{
+    m_manager.setLog(m_log);
+}
+    
+StreamableExecutor::~StreamableExecutor()
+{
+    //ABELL - Hmmm.
+    if (m_thread)
+        m_thread->join();
+}
+
+PyArrayObject *StreamableExecutor::executeNext()
+{
+    if (!m_thread)
+    {
+        m_thread.reset(new std::thread([this]()
+        {
+            m_manager.executeStream(m_table);
+        }));
+    }
+
+    // Blocks until something is ready.
+    PyArrayObject *arr = m_table.fetchArray();
+    if (arr == nullptr)
+    {
+        Py_BEGIN_ALLOW_THREADS
+        m_thread->join();
+        Py_END_ALLOW_THREADS
+        m_thread.reset();
+    }
+    return arr;
+}
+
+std::string StreamableExecutor::getMetadata() const
+{
+    return pdal::Utils::toJSON(m_manager.getMetadata().clone("metadata"));
+}
+
+std::string StreamableExecutor::getPipeline() const
+{
+    std::stringstream strm;
+    pdal::PipelineWriter::writePipeline(m_manager.getStage(), strm);
+    return strm.str();
+}
+
+int StreamableExecutor::getLogLevel() const
+{
+    return static_cast<int>(m_log->getLevel());
+}
+
+std::string StreamableExecutor::getLog() const
+{
+    return m_logStream.str();
+}
+
+// Returns the active log level.
+int StreamableExecutor::setLogLevel(int level)
+{
+    if (level < 0 || level > 8)
+        return getLogLevel();
+
+    m_log->setLevel(static_cast<pdal::LogLevel>(level));
+    return level;
+}
+
+bool StreamableExecutor::validate()
+{
+    std::stringstream strm;
+    strm << m_json;
+    m_manager.readPipeline(strm);
+    m_manager.prepare();
+
+    return true;
+}
+
+} // namespace python
+} // namespace pdal

--- a/pdal/StreamableExecutor.cpp
+++ b/pdal/StreamableExecutor.cpp
@@ -229,5 +229,16 @@ void StreamableExecutor::done()
     m_executed = true;
 }
 
+std::string StreamableExecutor::getSchema() const
+{
+    if (!m_executed)
+        throw pdal_error("Pipeline has not been executed!");
+
+    std::stringstream strm;
+    MetadataNode root = m_table.layout()->toMetadata().clone("schema");
+    pdal::Utils::toJSON(root, strm);
+    return strm.str();
+}
+
 } // namespace python
 } // namespace pdal

--- a/pdal/StreamableExecutor.hpp
+++ b/pdal/StreamableExecutor.hpp
@@ -34,18 +34,10 @@
 
 #pragma once
 
-#include <mutex>
 #include <condition_variable>
-#include <queue>
-#include <memory>
 #include <thread>
-#include <sstream>
 
-#include <numpy/arrayobject.h>
-
-#include <pdal/PipelineExecutor.hpp>
-#include <pdal/PipelineManager.hpp>
-#include <pdal/PointTable.hpp>
+#include "PyPipeline.hpp"
 
 namespace pdal
 {
@@ -85,7 +77,11 @@ private:
 class StreamableExecutor : public PipelineExecutor
 {
 public:
-    StreamableExecutor(std::string const& json, point_count_t chunkSize, int prefetch);
+    StreamableExecutor(std::string const& json,
+                       std::vector<std::shared_ptr<Array>> arrays,
+                       int level,
+                       point_count_t chunkSize,
+                       int prefetch);
     ~StreamableExecutor();
 
     std::string getSchema() const;
@@ -94,6 +90,7 @@ public:
 
 private:
     void done();
+    ConstPointTableRef pointTable() const { return m_table; }
 
     PythonPointTable m_table;
     std::unique_ptr<std::thread> m_thread;

--- a/pdal/StreamableExecutor.hpp
+++ b/pdal/StreamableExecutor.hpp
@@ -91,6 +91,7 @@ private:
 
     PythonPointTable m_table;
     std::unique_ptr<std::thread> m_thread;
+    std::exception_ptr m_exc;
 };
 
 } // namespace python

--- a/pdal/StreamableExecutor.hpp
+++ b/pdal/StreamableExecutor.hpp
@@ -43,6 +43,7 @@
 
 #include <numpy/arrayobject.h>
 
+#include <pdal/PipelineExecutor.hpp>
 #include <pdal/PipelineManager.hpp>
 #include <pdal/PointTable.hpp>
 
@@ -83,28 +84,17 @@ private:
     std::queue<PyArrayObject *> m_arrays;
 };
 
-class StreamableExecutor
+class StreamableExecutor : public PipelineExecutor
 {
 public:
-    StreamableExecutor(const char *json, int chunkSize, int prefetch);
+    StreamableExecutor(std::string const& json, point_count_t chunkSize, int prefetch);
     ~StreamableExecutor();
 
-    PyArrayObject *executeNext();
-    std::string getMetadata() const;
-    std::string getPipeline() const;
-    std::string getSchema() const;
-    std::string getLog() const;
-    int getLogLevel() const;
-    int setLogLevel(int level);
-    bool validate();
+    PyArrayObject* executeNext();
 
 private:
-    std::string m_json;
     int m_prefetch;
     PythonPointTable m_table;
-    PipelineManager m_manager;
-    std::stringstream m_logStream;
-    LogPtr m_log;
     std::unique_ptr<std::thread> m_thread;
 };
 

--- a/pdal/StreamableExecutor.hpp
+++ b/pdal/StreamableExecutor.hpp
@@ -59,6 +59,7 @@ public:
     ~PythonPointTable();
 
     virtual void finalize();
+    void disable();
     void done();
     PyArrayObject *fetchArray();
 
@@ -88,8 +89,11 @@ public:
     ~StreamableExecutor();
 
     PyArrayObject* executeNext();
+    void stop();
 
 private:
+    void done();
+
     PythonPointTable m_table;
     std::unique_ptr<std::thread> m_thread;
 };

--- a/pdal/StreamableExecutor.hpp
+++ b/pdal/StreamableExecutor.hpp
@@ -1,0 +1,112 @@
+/******************************************************************************
+* Copyright (c) 2016, Howard Butler (howard@hobu.co)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#pragma once
+
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+#include <memory>
+#include <thread>
+#include <sstream>
+
+#include <numpy/arrayobject.h>
+
+#include <pdal/PipelineManager.hpp>
+#include <pdal/PointTable.hpp>
+
+namespace pdal
+{
+namespace python
+{
+
+class PythonPointTable : public StreamPointTable
+{
+public:
+    PythonPointTable(point_count_t size, int prefetch);
+    ~PythonPointTable();
+
+    virtual void finalize();
+    PyArrayObject *fetchArray();
+
+protected:
+    virtual void reset();
+    virtual char *getPoint(PointId idx);
+
+private:
+    // All functions starting with py_ call Python things that need the GIL locked.
+    void py_destroy();
+    PyArrayObject *py_createArray() const;
+    void py_createDescriptor();
+    void py_resizeArray(int np);
+    PyObject *py_buildNumpyDescriptor() const;
+
+    point_count_t m_limit;
+    int m_prefetch;
+    PointLayout m_layout;
+    PyArrayObject *m_curArray;
+    PyArray_Descr *m_dtype;
+    std::mutex m_mutex;
+    std::condition_variable m_producedCv;
+    std::condition_variable m_consumedCv;
+    std::queue<PyArrayObject *> m_arrays;
+};
+
+class StreamableExecutor
+{
+public:
+    StreamableExecutor(const char *json, int chunkSize, int prefetch);
+    ~StreamableExecutor();
+
+    PyArrayObject *executeNext();
+    std::string getMetadata() const;
+    std::string getPipeline() const;
+    std::string getSchema() const;
+    std::string getLog() const;
+    int getLogLevel() const;
+    int setLogLevel(int level);
+    bool validate();
+
+private:
+    std::string m_json;
+    int m_prefetch;
+    PythonPointTable m_table;
+    PipelineManager m_manager;
+    std::stringstream m_logStream;
+    LogPtr m_log;
+    std::unique_ptr<std::thread> m_thread;
+};
+
+} // namespace python
+} // namespace pdal

--- a/pdal/StreamableExecutor.hpp
+++ b/pdal/StreamableExecutor.hpp
@@ -68,13 +68,10 @@ protected:
 
 private:
     // All functions starting with py_ call Python things that need the GIL locked.
-    void py_destroy();
-    PyArrayObject *py_createArray() const;
-    void py_createDescriptor();
-    void py_resizeArray(int np);
+    void py_createArray();
+    void py_resizeArray(point_count_t np);
     PyObject *py_buildNumpyDescriptor() const;
 
-    point_count_t m_limit;
     int m_prefetch;
     PointLayout m_layout;
     PyArrayObject *m_curArray;
@@ -94,7 +91,6 @@ public:
     PyArrayObject* executeNext();
 
 private:
-    int m_prefetch;
     PythonPointTable m_table;
     std::unique_ptr<std::thread> m_thread;
 };

--- a/pdal/StreamableExecutor.hpp
+++ b/pdal/StreamableExecutor.hpp
@@ -84,12 +84,9 @@ public:
                        int prefetch);
     ~StreamableExecutor();
 
-    std::string getSchema() const;
     PyArrayObject* executeNext();
-    void stop();
 
 private:
-    void done();
     ConstPointTableRef pointTable() const { return m_table; }
 
     PythonPointTable m_table;

--- a/pdal/StreamableExecutor.hpp
+++ b/pdal/StreamableExecutor.hpp
@@ -70,7 +70,6 @@ private:
     // All functions starting with py_ call Python things that need the GIL locked.
     void py_createArray();
     void py_resizeArray(point_count_t np);
-    PyObject *py_buildNumpyDescriptor() const;
 
     int m_prefetch;
     PointLayout m_layout;

--- a/pdal/StreamableExecutor.hpp
+++ b/pdal/StreamableExecutor.hpp
@@ -59,6 +59,7 @@ public:
     ~PythonPointTable();
 
     virtual void finalize();
+    void done();
     PyArrayObject *fetchArray();
 
 protected:

--- a/pdal/StreamableExecutor.hpp
+++ b/pdal/StreamableExecutor.hpp
@@ -88,6 +88,7 @@ public:
     StreamableExecutor(std::string const& json, point_count_t chunkSize, int prefetch);
     ~StreamableExecutor();
 
+    std::string getSchema() const;
     PyArrayObject* executeNext();
     void stop();
 

--- a/pdal/__init__.py
+++ b/pdal/__init__.py
@@ -1,18 +1,8 @@
 __version__ = "2.4.2"
-__all__ = [
-    "Pipeline",
-    "PipelineIterator",
-    "Stage",
-    "Reader",
-    "Filter",
-    "Writer",
-    "dimensions",
-    "info",
-]
+__all__ = ["Pipeline", "Stage", "Reader", "Filter", "Writer", "dimensions", "info"]
 
 from . import libpdalpython
 from .drivers import inject_pdal_drivers
-from .libpdalpython import PipelineIterator
 from .pipeline import Filter, Pipeline, Reader, Stage, Writer
 
 inject_pdal_drivers()

--- a/pdal/__init__.py
+++ b/pdal/__init__.py
@@ -1,8 +1,18 @@
 __version__ = "2.4.2"
-__all__ = ["Pipeline", "Stage", "Reader", "Filter", "Writer", "dimensions", "info"]
+__all__ = [
+    "Pipeline",
+    "PipelineIterator",
+    "Stage",
+    "Reader",
+    "Filter",
+    "Writer",
+    "dimensions",
+    "info",
+]
 
 from . import libpdalpython
 from .drivers import inject_pdal_drivers
+from .libpdalpython import PipelineIterator
 from .pipeline import Filter, Pipeline, Reader, Stage, Writer
 
 inject_pdal_drivers()

--- a/pdal/libpdalpython.pyx
+++ b/pdal/libpdalpython.pyx
@@ -180,7 +180,7 @@ cdef class Pipeline(PipelineResultsMixin):
     def arrays(self):
         cdef PipelineExecutor* executor = self._get_executor()
         if not executor.executed():
-            raise RuntimeError("call execute() before fetching arrays")
+            raise RuntimeError("Pipeline has not been executed!")
         output = []
         for view in executor.getManagerConst().views():
             output.append(<object>viewToNumpyArray(view))
@@ -191,7 +191,7 @@ cdef class Pipeline(PipelineResultsMixin):
     def meshes(self):
         cdef PipelineExecutor* executor = self._get_executor()
         if not executor.executed():
-            raise RuntimeError("call execute() before fetching the mesh")
+            raise RuntimeError("Pipeline has not been executed!")
         output = []
         for view in executor.getManagerConst().views():
             output.append(<object>meshToNumpyArray(deref(view).mesh()))

--- a/pdal/libpdalpython.pyx
+++ b/pdal/libpdalpython.pyx
@@ -239,6 +239,7 @@ cdef class Pipeline(PipelineResultsMixin):
         addArrayReaders(executor, self._inputs)
 
 
+@cython.internal
 cdef class PipelineIterator(PipelineResultsMixin):
     cdef unique_ptr[StreamableExecutor] _executor
 

--- a/pdal/libpdalpython.pyx
+++ b/pdal/libpdalpython.pyx
@@ -92,6 +92,7 @@ cdef extern from "PyPipeline.hpp" namespace "pdal::python":
     cdef cppclass PipelineExecutor:
         PipelineExecutor(string, vector[shared_ptr[Array]], int) except +
         int execute() except +
+        int executeStream(int) except +
         string getPipeline() except +
         string getMetadata() except +
         string getSchema() except +
@@ -184,6 +185,9 @@ cdef class Pipeline(PipelineResultsMixin):
 
     def execute(self):
         return self._get_executor().execute()
+
+    def execute_streaming(self, int chunk_size=10000):
+        return self._get_executor().executeStream(chunk_size)
 
     def iterator(self, int chunk_size=10000, int prefetch = 0):
         it = PipelineIterator()

--- a/pdal/libpdalpython.pyx
+++ b/pdal/libpdalpython.pyx
@@ -250,9 +250,6 @@ cdef class PipelineIterator(PipelineResultsMixin):
     cdef set_executor(self, StreamableExecutor* executor):
         self._executor.reset(executor)
 
-    def __dealloc__(self):
-        self._executor.get().stop()
-
     @property
     def schema(self):
         return json.loads(self._executor.get().getSchema())

--- a/pdal/libpdalpython.pyx
+++ b/pdal/libpdalpython.pyx
@@ -89,6 +89,7 @@ cdef extern from "pdal/PointView.hpp" namespace "pdal":
 cdef extern from "pdal/PipelineManager.hpp" namespace "pdal":
     cdef cppclass PipelineManager:
         const PointViewSet& views() const
+        bool pipelineStreamable() const
 
 
 cdef extern from "pdal/PipelineExecutor.hpp" namespace "pdal":
@@ -207,6 +208,9 @@ cdef class Pipeline(PipelineResultsMixin):
             self._get_json(), chunk_size, prefetch
         )
         self._configure_executor(executor)
+        if not executor.getManagerConst().pipelineStreamable():
+            raise RuntimeError("Pipeline is not streamable")
+
         it = PipelineIterator()
         it.set_executor(executor)
         return it

--- a/pdal/libpdalpython.pyx
+++ b/pdal/libpdalpython.pyx
@@ -248,6 +248,10 @@ cdef class PipelineIterator(PipelineResultsMixin):
     def __dealloc__(self):
         self._executor.get().stop()
 
+    @property
+    def schema(self):
+        return json.loads(self._executor.get().getSchema())
+
     def __iter__(self):
         return self
 

--- a/pdal/libpdalpython.pyx
+++ b/pdal/libpdalpython.pyx
@@ -113,6 +113,44 @@ cdef extern from "PyPipeline.hpp" namespace "pdal::python":
     np.PyArrayObject* viewToNumpyArray(PointViewPtr) except +
     np.PyArrayObject* meshToNumpyArray(const TriangularMesh*) except +
 
+cdef extern from "StreamableExecutor.hpp" namespace "pdal::python":
+    cdef cppclass StreamableExecutor:
+        StreamableExecutor(const char *, int, int) except +
+        np.PyArrayObject *executeNext() except +
+        bool validate() except +
+        string getMetadata() except +
+        string getPipeline() except +
+        string getSchema() except +
+        string getLog() except +
+        int getLogLevel() except +
+        int setLogLevel(int level) except +
+
+
+cdef class PipelineIterator:
+    cdef int _chunk_size
+    cdef StreamableExecutor *_executor;
+
+    def __cinit__(self, unicode json, list arrays=None, int chunk_size=10000, int prefetch=0):
+        self._chunk_size
+        self._executor = new StreamableExecutor(json.encode("UTF-8"), chunk_size, prefetch)
+#        self._add_arrays(arrays)
+
+    property chunk_size:
+        def __get__(self):
+            return self._chunk_size
+
+    def validate(self):
+        return self._executor.validate()
+
+    def __iter__(self):
+        while True:
+            arrPtr = self._executor.executeNext()
+            if arrPtr is NULL:
+                break
+            arr = <object>arrPtr
+            Py_DECREF(arr)
+            yield arr
+
 
 cdef class Pipeline:
     cdef unique_ptr[PipelineExecutor] _executor

--- a/pdal/pipeline.py
+++ b/pdal/pipeline.py
@@ -28,6 +28,8 @@ class Pipeline(libpdalpython.Pipeline):
         spec: Union[None, str, Sequence[Stage]] = None,
         arrays: Sequence[np.ndarray] = (),
         loglevel: int = logging.ERROR,
+        chunk_size: int = 10000,
+        prefetch: int = 0,
     ):
         super().__init__()
         self._stages: List[Stage] = []
@@ -37,6 +39,8 @@ class Pipeline(libpdalpython.Pipeline):
                 self |= stage
         self.inputs = arrays
         self.loglevel = loglevel
+        self.chunk_size = chunk_size
+        self.prefetch = prefetch
 
     @property
     def stages(self) -> List[Stage]:

--- a/pdal/pipeline.py
+++ b/pdal/pipeline.py
@@ -28,8 +28,6 @@ class Pipeline(libpdalpython.Pipeline):
         spec: Union[None, str, Sequence[Stage]] = None,
         arrays: Sequence[np.ndarray] = (),
         loglevel: int = logging.ERROR,
-        chunk_size: int = 10000,
-        prefetch: int = 0,
     ):
         super().__init__()
         self._stages: List[Stage] = []
@@ -39,8 +37,6 @@ class Pipeline(libpdalpython.Pipeline):
                 self |= stage
         self.inputs = arrays
         self.loglevel = loglevel
-        self.chunk_size = chunk_size
-        self.prefetch = prefetch
 
     @property
     def stages(self) -> List[Stage]:
@@ -49,10 +45,6 @@ class Pipeline(libpdalpython.Pipeline):
     @property
     def streamable(self) -> bool:
         return all(stage.streamable for stage in self._stages)
-
-    @property
-    def schema(self) -> Any:
-        return json.loads(super().schema)
 
     @property
     def loglevel(self) -> int:

--- a/test/data/range.json
+++ b/test/data/range.json
@@ -1,0 +1,7 @@
+[
+  "test/data/autzen-utm.las",
+  {
+    "type": "filters.range",
+    "limits": "Intensity[80:120)"
+  }
+]

--- a/test/data/range.py
+++ b/test/data/range.py
@@ -1,0 +1,1 @@
+Reader("test/data/autzen-utm.las") | Filter.range(limits="Intensity[80:120)")

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -408,6 +408,12 @@ class TestMesh:
 
 
 class TestPipelineIterator:
+    @pytest.mark.parametrize("filename", ["sort.json", "sort.py"])
+    def test_non_streamable(self, filename):
+        r = get_pipeline(filename)
+        with pytest.raises(RuntimeError) as info:
+            r.iterator()
+        assert str(info.value) == "Pipeline is not streamable"
 
     @pytest.mark.parametrize("filename", ["range.json", "range.py"])
     def test_array(self, filename):

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -84,7 +84,10 @@ class TestPipeline:
         r = get_pipeline(filename)
         with pytest.raises(RuntimeError) as info:
             r.execute()
-        assert "No such file or directory" in str(info.value)
+        if os.name == "nt":
+            assert "Unable to open stream for" in str(info.value)
+        else:
+            assert "No such file or directory" in str(info.value)
 
     @pytest.mark.parametrize("filename", ["sort.json", "sort.py"])
     def test_array(self, filename):

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -436,9 +436,10 @@ class TestPipelineIterator:
     @pytest.mark.parametrize("filename", ["sort.json", "sort.py"])
     def test_non_streamable(self, filename):
         r = get_pipeline(filename)
+        assert not r.streamable
         with pytest.raises(RuntimeError) as info:
-            r.iterator()
-        assert "Pipeline is not streamable" in str(info.value)
+            next(r.iterator(chunk_size=100))
+        assert "Attempting to use stream mode" in str(info.value)
 
     @pytest.mark.parametrize("filename", ["range.json", "range.py"])
     def test_array(self, filename):

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -66,8 +66,9 @@ class TestPipeline:
     def test_validate(self, filename):
         """Do we complain with bad pipelines"""
         r = get_pipeline(filename)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as info:
             r.execute()
+        assert "No such file or directory" in str(info.value)
 
     @pytest.mark.parametrize("filename", ["sort.json", "sort.py"])
     def test_array(self, filename):
@@ -85,8 +86,9 @@ class TestPipeline:
     def test_metadata(self, filename):
         """Can we fetch PDAL metadata"""
         r = get_pipeline(filename)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as info:
             r.metadata
+        assert "Pipeline has not been executed" in str(info.value)
 
         r.execute()
         j = json.loads(r.metadata)
@@ -96,8 +98,9 @@ class TestPipeline:
     def test_schema(self, filename):
         """Fetching a schema works"""
         r = get_pipeline(filename)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as info:
             r.schema
+        assert "Pipeline has not been executed" in str(info.value)
 
         r.execute()
         assert r.schema["schema"]["dimensions"][0]["name"] == "X"
@@ -106,8 +109,9 @@ class TestPipeline:
     def test_pipeline(self, filename):
         """Can we fetch PDAL pipeline string"""
         r = get_pipeline(filename)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as info:
             r.pipeline
+        assert "Pipeline has not been executed" in str(info.value)
 
         r.execute()
         assert json.loads(r.pipeline) == {
@@ -131,8 +135,9 @@ class TestPipeline:
     def test_no_execute(self, filename):
         """Does fetching arrays without executing throw an exception"""
         r = get_pipeline(filename)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as info:
             r.arrays
+        assert "Pipeline has not been executed" in str(info.value)
 
     @pytest.mark.parametrize("filename", ["chip.json", "chip.py"])
     def test_merged_arrays(self, filename):
@@ -193,9 +198,9 @@ class TestPipeline:
             (r, f) | (f, w)
 
         pipeline = r | w
-        with pytest.raises(RuntimeError) as ctx:
+        with pytest.raises(RuntimeError) as info:
             pipeline.execute()
-        assert "Undefined stage 'f'" in str(ctx.value)
+        assert "Undefined stage 'f'" in str(info.value)
 
     def test_inputs(self):
         """Can we combine pipelines with inputs"""
@@ -380,8 +385,9 @@ class TestMesh:
     def test_no_execute(self, filename):
         """Does fetching meshes without executing throw an exception"""
         r = get_pipeline(filename)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as info:
             r.meshes
+        assert "Pipeline has not been executed" in str(info.value)
 
     @pytest.mark.parametrize("filename", ["mesh.json", "mesh.py"])
     def test_mesh(self, filename):
@@ -413,7 +419,7 @@ class TestPipelineIterator:
         r = get_pipeline(filename)
         with pytest.raises(RuntimeError) as info:
             r.iterator()
-        assert str(info.value) == "Pipeline is not streamable"
+        assert "Pipeline is not streamable" in str(info.value)
 
     @pytest.mark.parametrize("filename", ["range.json", "range.py"])
     def test_array(self, filename):
@@ -483,8 +489,9 @@ class TestPipelineIterator:
         non_streaming_array = np.concatenate(p.arrays)
         for chunk_size in range(5, 100, 5):
             streaming_arrays = list(p.iterator(chunk_size=chunk_size))
-            np.testing.assert_array_equal(np.concatenate(streaming_arrays),
-                                          non_streaming_array)
+            np.testing.assert_array_equal(
+                np.concatenate(streaming_arrays), non_streaming_array
+            )
 
     @pytest.mark.parametrize("filename", ["range.json", "range.py"])
     def test_premature_exit(self, filename):
@@ -496,7 +503,7 @@ class TestPipelineIterator:
 
         for _ in range(10):
             for array2 in r.iterator(chunk_size=100):
-                np.testing.assert_array_equal(array2, array[:len(array2)])
+                np.testing.assert_array_equal(array2, array[: len(array2)])
                 break
 
     @pytest.mark.parametrize("filename", ["range.json", "range.py"])

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -56,11 +56,27 @@ class TestPipeline:
             pdal.Pipeline(pipeline)
 
     @pytest.mark.parametrize("filename", ["sort.json", "sort.py"])
-    def test_execution(self, filename):
+    def test_execute(self, filename):
         """Can we execute a PDAL pipeline"""
         r = get_pipeline(filename)
         r.execute()
         assert len(r.pipeline) > 200
+
+    @pytest.mark.parametrize("filename", ["range.json", "range.py"])
+    def test_execute_streaming(self, filename):
+        r = get_pipeline(filename)
+        assert r.streamable
+        count = r.execute()
+        count2 = r.execute_streaming(chunk_size=100)
+        assert count == count2
+
+    @pytest.mark.parametrize("filename", ["sort.json", "sort.py"])
+    def test_execute_streaming_non_streamable(self, filename):
+        r = get_pipeline(filename)
+        assert not r.streamable
+        with pytest.raises(RuntimeError) as info:
+            r.execute_streaming()
+        assert "Attempting to use stream mode" in str(info.value)
 
     @pytest.mark.parametrize("filename", ["bad.json", "bad.py"])
     def test_validate(self, filename):

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -445,7 +445,6 @@ class TestPipelineIterator:
 
         assert r.metadata == it.metadata
 
-    @pytest.mark.xfail
     def test_schema(self):
         """Fetching a schema works"""
         r = get_pipeline("range.json")

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -419,7 +419,6 @@ class TestMesh:
 
 class TestPipelineIterator:
 
-    @pytest.mark.xfail
     def test_array(self):
         """Can we fetch PDAL data as numpy arrays"""
         ri = get_pipeline("range.json", chunk_size=100)

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -409,9 +409,10 @@ class TestMesh:
 
 class TestPipelineIterator:
 
-    def test_array(self):
+    @pytest.mark.parametrize("filename", ["range.json", "range.py"])
+    def test_array(self, filename):
         """Can we fetch PDAL data as numpy arrays"""
-        r = get_pipeline("range.json")
+        r = get_pipeline(filename)
         count = r.execute()
         arrays = r.arrays
         assert len(arrays) == 1
@@ -424,9 +425,10 @@ class TestPipelineIterator:
             concat_array = np.concatenate(arrays)
             np.testing.assert_array_equal(array, concat_array)
 
-    def test_StopIteration(self):
+    @pytest.mark.parametrize("filename", ["range.json", "range.py"])
+    def test_StopIteration(self, filename):
         """Is StopIteration raised when the iterator is exhausted"""
-        r = get_pipeline("range.json")
+        r = get_pipeline(filename)
         it = r.iterator(chunk_size=100)
         for array in it:
             assert isinstance(array, np.ndarray)
@@ -434,9 +436,10 @@ class TestPipelineIterator:
             next(it)
         assert next(it, None) is None
 
-    def test_metadata(self):
+    @pytest.mark.parametrize("filename", ["range.json", "range.py"])
+    def test_metadata(self, filename):
         """Can we fetch PDAL metadata"""
-        r = get_pipeline("range.json")
+        r = get_pipeline(filename)
         r.execute()
 
         it = r.iterator(chunk_size=100)
@@ -445,9 +448,10 @@ class TestPipelineIterator:
 
         assert r.metadata == it.metadata
 
-    def test_schema(self):
+    @pytest.mark.parametrize("filename", ["range.json", "range.py"])
+    def test_schema(self, filename):
         """Fetching a schema works"""
-        r = get_pipeline("range.json")
+        r = get_pipeline(filename)
         r.execute()
 
         it = r.iterator(chunk_size=100)
@@ -476,9 +480,10 @@ class TestPipelineIterator:
             np.testing.assert_array_equal(np.concatenate(streaming_arrays),
                                           non_streaming_array)
 
-    def test_premature_exit(self):
+    @pytest.mark.parametrize("filename", ["range.json", "range.py"])
+    def test_premature_exit(self, filename):
         """Can we stop iterating before all arrays are fetched"""
-        r = get_pipeline("range.json")
+        r = get_pipeline(filename)
         r.execute()
         assert len(r.arrays) == 1
         array = r.arrays[0]
@@ -488,9 +493,10 @@ class TestPipelineIterator:
                 np.testing.assert_array_equal(array2, array[:len(array2)])
                 break
 
-    def test_multiple_iterators(self):
+    @pytest.mark.parametrize("filename", ["range.json", "range.py"])
+    def test_multiple_iterators(self, filename):
         """Can we create multiple independent iterators"""
-        r = get_pipeline("range.json")
+        r = get_pipeline(filename)
         it1 = r.iterator(chunk_size=100)
         it2 = r.iterator(chunk_size=100)
         for a1, a2 in zip(it1, it2):

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -484,3 +484,15 @@ class TestPipelineIterator:
                                                   chunk_size=chunk_size))
             np.testing.assert_array_equal(np.concatenate(streaming_arrays),
                                           non_streaming_array)
+
+    def test_premature_exit(self):
+        """Can we stop iterating before all arrays are fetched"""
+        r = get_pipeline("range.json")
+        r.execute()
+        assert len(r.arrays) == 1
+        array = r.arrays[0]
+
+        ri = get_pipeline("range.json", chunk_size=100)
+        for array2 in ri:
+            np.testing.assert_array_equal(array2, array[:len(array2)])
+            break


### PR DESCRIPTION
Alternative implementation of #90 using a separate thread to execute the pipeline in streaming mode in the background, with minimal changes to PDAL core. Thanks to @abellgithub for the idea and the [initial implementation](https://github.com/PDAL/python/commit/c383e79704b54558bffa6ce51da5f60752a486fa).

This PR is built on top of #91. ~It also requires https://github.com/PDAL/PDAL/pull/3567; there is a [temporary commit](https://github.com/PDAL/python/commit/9d9439482cdb437ea67896d47cb489eaa3736ab4) for running the CI (Python 3.8 only) against a custom PDAL build that uses the aforementioned PR.~