### PR TITLE
fix: avoid mutable list as class attributable in `pdal.pio.PipelineSpec`

### DIFF
--- a/pdal/pio.py
+++ b/pdal/pio.py
@@ -93,9 +93,8 @@ writers = StageSpec("writers")
 
 
 class PipelineSpec(object):
-    stages = []
-
     def __init__(self, other=None):
+        self.stages = []
         if other is not None:
             self.stages = copy.copy(other.stages)
 


### PR DESCRIPTION
The `pdal.pio.PipelineSpec` class defines the class atribute `stages` as an empty list:

https://github.com/PDAL/python/blob/3b534aff4cfafef8dc93425f377adc506c22c237/pdal/pio.py#L96

Because lists are mutable objects, this creates adverse consequences when defining multiple pipelines in the same runtime. An example: 

```
>>> from pdal import pio

>>> a_pipeline = pio.readers.las(filename="file.laz")
>>> a_pipeline.pipeline # needed to instantiate PipelineSpec()
<pdal.pio.PipelineSpec object at 0x101e7fdc0>

>>> another_pipeline = pio.readers.las(filename="file.laz")
>>> another_pipeline.pipeline
<pdal.pio.PipelineSpec object at 0x101ed5940>

>>> yet_another_pipeline = pio.readers.las(filename="file.laz")
>>> len(yet_another_pipeline.pipeline.stages)
3
```

This PR fixes this by first defining `stages` as a instance attribute instead.