### PR TITLE
implement QuickInfo support

### DIFF
--- a/pdal/PyPipeline.hpp
+++ b/pdal/PyPipeline.hpp
@@ -59,6 +59,7 @@ public:
     const PointViewSet& views() const;
     std::string getPipeline() const;
     std::string getMetadata() const;
+    std::string getQuickInfo() const;
     std::string getSchema() const;
     std::string getLog() const { return m_logStream.str(); }
 

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -95,6 +95,8 @@ namespace pdal {
 
         std::string getPipeline() { return getExecutor()->getPipeline(); }
 
+        std::string getQuickInfo() { return getExecutor()->getQuickInfo(); }
+
         std::string getMetadata() { return getExecutor()->getMetadata(); }
 
         py::object getSchema() {
@@ -161,6 +163,7 @@ namespace pdal {
         .def_property_readonly("log", &Pipeline::getLog)
         .def_property_readonly("schema", &Pipeline::getSchema)
         .def_property_readonly("pipeline", &Pipeline::getPipeline)
+        .def_property_readonly("quickinfo", &Pipeline::getQuickInfo)
         .def_property_readonly("metadata", &Pipeline::getMetadata)
         .def_property_readonly("arrays", &Pipeline::getArrays)
         .def_property_readonly("meshes", &Pipeline::getMeshes)

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -362,6 +362,12 @@ class TestPipeline:
         assert count2 == 2 * count1
         np.testing.assert_array_equal(np.concatenate([array1, array1]), array2)
 
+    def test_quickinfo(self):
+        r = pdal.Reader("test/data/autzen-utm.las")
+        p = r.pipeline()
+        info = json.loads(p.quickinfo)
+        assert 'readers.las' in info.keys()
+        assert info['readers.las']['num_points'] == 1065
 
 class TestArrayLoad:
     def test_merged_arrays(self):


### PR DESCRIPTION
Many readers support QuickInfo for fetching stuff about a data source without executing a pipeline. This is quite useful for asking information from COPC and LAS files, for example.