### PR TITLE
add pickling support for Pipeline

### DIFF
--- a/pdal/PyPipeline.cpp
+++ b/pdal/PyPipeline.cpp
@@ -100,9 +100,6 @@ const PointViewSet& PipelineExecutor::views() const
 
 std::string PipelineExecutor::getPipeline() const
 {
-    if (!m_executed)
-        throw pdal_error("Pipeline has not been executed!");
-
     std::stringstream strm;
     pdal::PipelineWriter::writePipeline(m_manager.getStage(), strm);
     return strm.str();

--- a/pdal/pipeline.py
+++ b/pdal/pipeline.py
@@ -38,6 +38,13 @@ class Pipeline(libpdalpython.Pipeline):
         self.inputs = arrays
         self.loglevel = loglevel
 
+    def __getstate__(self):
+        state = self.pipeline
+        return state
+
+    def __setstate__(self, state):
+        self.__init__(state)
+
     @property
     def stages(self) -> List[Stage]:
         return list(self._stages)

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -132,10 +132,6 @@ class TestPipeline:
     def test_pipeline(self, filename):
         """Can we fetch PDAL pipeline string"""
         r = get_pipeline(filename)
-        with pytest.raises(RuntimeError) as info:
-            r.pipeline
-        assert "Pipeline has not been executed" in str(info.value)
-
         r.execute()
         assert json.loads(r.pipeline) == {
             "pipeline": [


### PR DESCRIPTION
This changes a behavior of the base library throwing when you ask for a pipeline if it hadn't been executed. That was really a consequence of the old design and is no longer needed.

This patch is needed for convenient Dask operations.