### PR TITLE
Interface updates

### DIFF
--- a/pdal/StreamableExecutor.hpp
+++ b/pdal/StreamableExecutor.hpp
@@ -84,6 +84,7 @@ public:
                        int prefetch);
     ~StreamableExecutor();
 
+    MetadataNode getMetadata() { return m_table.metadata(); }
     PyArrayObject* executeNext();
 
 private:

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -129,6 +129,23 @@ namespace pdal {
             return py::reinterpret_steal<py::array>((PyObject*)arr);
         }
 
+        py::object getMetadata() {
+            py::object json = py::module_::import("json");
+
+            std::stringstream strm;
+            MetadataNode root = (StreamableExecutor::getMetadata()).clone("metadata");
+            pdal::Utils::toJSON(root, strm);
+
+            py::str pystring(strm.str());
+            pystring.attr("strip");
+
+            py::object j;
+            j = json.attr("loads")(pystring);
+
+            return j;
+
+        }
+
     };
 
     class Pipeline {
@@ -162,9 +179,23 @@ namespace pdal {
 
         std::string getPipeline() { return getExecutor()->getPipeline(); }
 
-        std::string getQuickInfo() { return getExecutor()->getQuickInfo(); }
+        py::object getQuickInfo() {
+            py::gil_scoped_acquire acquire;
+            py::object json = py::module_::import("json");
 
-        std::string getMetadata() { return getExecutor()->getMetadata(); }
+            py::str pystring(getExecutor()->getQuickInfo());
+            pystring.attr("strip");
+
+            py::object j;
+            j = json.attr("loads")(pystring);
+
+            return j;
+
+        }
+
+        py::object getMetadata() {
+            return py::module_::import("json").attr("loads")(getExecutor()->getMetadata());
+        }
 
         py::object getSchema() {
             return py::module_::import("json").attr("loads")(getExecutor()->getSchema());

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -114,8 +114,7 @@ class TestPipeline:
         assert "Pipeline has not been executed" in str(info.value)
 
         r.execute()
-        j = json.loads(r.metadata)
-        assert j["metadata"]["readers.las"]["count"] == 1065
+        assert r.metadata["metadata"]["readers.las"]["count"] == 1065
 
     @pytest.mark.parametrize("filename", ["sort.json", "sort.py"])
     def test_schema(self, filename):
@@ -361,7 +360,7 @@ class TestPipeline:
     def test_quickinfo(self):
         r = pdal.Reader("test/data/autzen-utm.las")
         p = r.pipeline()
-        info = json.loads(p.quickinfo)
+        info = p.quickinfo
         assert 'readers.las' in info.keys()
         assert info['readers.las']['num_points'] == 1065
 


### PR DESCRIPTION
* Make pipeline.metadata return an object instead of string
* Make pipeline.quickinfo return an object instead of a string
* Add iterator.metadata to return PointTable metadata