### PR TITLE
harden getMetadata and related calls from getting non-utf-8 'json' 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - name: Check out python-pdal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           python=${{ matrix.python-version }}
 
     - name: Install python-pdal
-      run: pip install -e .
+      run: pip install .
 
     - name: Install python-pdal-plugins
       working-directory: ./plugins

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
         tree ./dist
 
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       if: github.event_name == 'release' && github.event.action == 'published'
       with:
         user: __token__

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           python=${{ matrix.python-version }}
 
     - name: Install python-pdal
-      run: pip install .
+      run: pip install . -e
 
     - name: Install python-pdal-plugins
       working-directory: ./plugins

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Test
       run: |
-        export PDAL_DRIVER_PATH=$(python -c "import os, skbuild; print(os.path.join('plugins', skbuild.constants.SKBUILD_DIR(), 'cmake-build'))")
+        # export PDAL_DRIVER_PATH=$(python -c "import os, skbuild; print(os.path.join('plugins', skbuild.constants.SKBUILD_DIR(), 'cmake-build'))")
         pdal --drivers
         py.test -v test/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,11 +50,14 @@ jobs:
       working-directory: ./plugins
       run: pip install .
 
+    - name: Install pytest
+      run: pip install pytest
+
     - name: Test
       run: |
         export PDAL_DRIVER_PATH=$(python -c "import os, skbuild; print(os.path.join('plugins', skbuild.constants.SKBUILD_DIR(), 'cmake-build'))")
         pdal --drivers
-        python -m pytest -v test/
+        py.test -v test/
 
     - name: Build wheel distribution
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Test
       run: |
-        # export PDAL_DRIVER_PATH=$(python -c "import os, skbuild; print(os.path.join('plugins', skbuild.constants.SKBUILD_DIR(), 'cmake-build'))")
+        export PDAL_DRIVER_PATH=$(python -c "import os, skbuild; print(os.path.join('plugins', skbuild.constants.SKBUILD_DIR(), 'cmake-build'))")
         pdal --drivers
         py.test -v test/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         export PDAL_DRIVER_PATH=$(python -c "import os, skbuild; print(os.path.join('plugins', skbuild.constants.SKBUILD_DIR(), 'cmake-build'))")
         pdal --drivers
-        py.test -v test/
+        python -m pytest -v test/
 
     - name: Build wheel distribution
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       run: pip install .
 
     - name: Install pytest
-      run: pip install pytest
+      run: pip install --upgrade --force-reinstall pytest
 
     - name: Test
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           python=${{ matrix.python-version }}
 
     - name: Install python-pdal
-      run: pip install . -e
+      run: pip install -e .
 
     - name: Install python-pdal-plugins
       working-directory: ./plugins

--- a/pdal/__init__.py
+++ b/pdal/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 __all__ = ["Pipeline", "Stage", "Reader", "Filter", "Writer", "dimensions", "info"]
 
 from . import libpdalpython

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -183,7 +183,7 @@ namespace pdal {
             py::gil_scoped_acquire acquire;
             py::object json = py::module_::import("json");
 
-            py::str pybytes(getExecutor()->getQuickInfo());
+            py::pybytes pybytes(getExecutor()->getQuickInfo());
 
             py::str pystring ( pybytes.attr("decode")("utf-8", "ignore"));
             pystring.attr("strip");

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -134,8 +134,9 @@ namespace pdal {
             MetadataNode root = (StreamableExecutor::getMetadata()).clone("metadata");
             pdal::Utils::toJSON(root, strm);
 
-            py::str pystring(strm.str());
-            pystring.attr("strip");
+
+            py::bytes pybytes(strm.str());
+            py::str pystring ( pybytes.attr("decode")("utf-8", "ignore"));
 
             py::object j;
             j = json.attr("loads")(pystring);
@@ -182,7 +183,9 @@ namespace pdal {
             py::gil_scoped_acquire acquire;
             py::object json = py::module_::import("json");
 
-            py::str pystring(getExecutor()->getQuickInfo());
+            py::str pybytes(getExecutor()->getQuickInfo());
+
+            py::str pystring ( pybytes.attr("decode")("utf-8", "ignore"));
             pystring.attr("strip");
 
             py::object j;
@@ -193,7 +196,16 @@ namespace pdal {
         }
 
         py::object getMetadata() {
-            return py::module_::import("json").attr("loads")(getExecutor()->getMetadata());
+            py::object json = py::module_::import("json");
+
+            py::bytes pybytes(getExecutor()->getMetadata());
+            py::str pystring ( pybytes.attr("decode")("utf-8", "ignore"));
+
+            py::object j;
+            j = json.attr("loads")(pystring);
+
+            return j;
+
         }
 
         py::object getSchema() {

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -183,7 +183,7 @@ namespace pdal {
             py::gil_scoped_acquire acquire;
             py::object json = py::module_::import("json");
 
-            py::pybytes pybytes(getExecutor()->getQuickInfo());
+            py::bytes pybytes(getExecutor()->getQuickInfo());
 
             py::str pystring ( pybytes.attr("decode")("utf-8", "ignore"));
             pystring.attr("strip");

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -34,7 +34,7 @@ def get_pipeline(filename):
 def test_dimensions():
     """Ask PDAL for its valid dimensions list"""
     dims = pdal.dimensions
-    assert 71 < len(dims) < 120
+    assert 71 < len(dims) < 122
 
 
 class TestPipeline:
@@ -500,6 +500,10 @@ class TestDataFrame:
         df = p.get_dataframe(0)
         assert df.size == 17040
 
+    @pytest.mark.skipif(
+        not pdal.pipeline.DataFrame,
+        reason="pandas is not available",
+    )
     def test_load(self):
         r = pdal.Reader(os.path.join(DATADIRECTORY,"autzen-utm.las"))
         p = r.pipeline()


### PR DESCRIPTION
PDAL's metadata can spit non-utf8 characters into its JSON output. This patch will ignore them, and we'll also patch PDAL to not spit out utf-8 in its JSON going forward at 2.5.0+

This should fix https://github.com/PDAL/PDAL/issues/3880 once released.