### PR TITLE
Cleanup GIL stuff

### DIFF
--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -189,7 +189,6 @@ namespace pdal {
         }
 
         void setInputs(std::vector<py::array> ndarrays) {
-            py::gil_scoped_acquire acquire;
             _inputs.clear();
             for (const auto& ndarray: ndarrays) {
                 PyArrayObject* ndarray_ptr = (PyArrayObject*)ndarray.ptr();

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -169,7 +169,12 @@ namespace pdal {
         }
 
         point_count_t executeStream(point_count_t streamLimit) {
-            return  getExecutor()->executeStream(streamLimit);
+            point_count_t response(0);
+            {
+                py::gil_scoped_release release;
+                response = getExecutor()->executeStream(streamLimit);
+            }
+            return response;
         }
 
         std::unique_ptr<PipelineIterator> iterator(int chunk_size, int prefetch) {

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -267,6 +267,10 @@ namespace pdal {
         void delExecutor() { _executor.reset(); }
 
         PipelineExecutor* getExecutor() {
+            // We need to acquire the GIL before we create the executor
+            // because this method does Python init stuff but pybind11 doesn't
+            // automatically encapsulate it with a gil_scoped_acquire like it
+            // does for all of the other methods it knows about
             py::gil_scoped_acquire acquire;
             if (!_executor)
                 _executor.reset(new PipelineExecutor(getJson(), _inputs, _loglevel));

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -272,7 +272,6 @@ namespace pdal {
         void delExecutor() { _executor.reset(); }
 
         PipelineExecutor* getExecutor() {
-            py::gil_scoped_acquire acquire;
             if (!_executor)
                 _executor.reset(new PipelineExecutor(getJson(), _inputs, _loglevel));
             return _executor.get();

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -30,6 +30,7 @@ namespace pdal {
     };
 
    std::vector<py::dict> getDrivers() {
+        py::gil_scoped_acquire acquire;
         std::vector<py::dict> drivers;
 
         pdal::StageFactory f(false);
@@ -58,6 +59,7 @@ namespace pdal {
     };
 
    py::object getOptions() {
+        py::gil_scoped_acquire acquire;
         py::object json = py::module_::import("json");
         py::dict stageOptions;
 
@@ -92,6 +94,7 @@ namespace pdal {
     };
 
     std::vector<py::dict> getDimensions() {
+        py::gil_scoped_acquire acquire;
         py::object np = py::module_::import("numpy");
         py::object dtype = np.attr("dtype");
         std::vector<py::dict> dims;
@@ -109,11 +112,13 @@ namespace pdal {
 
     std::string getReaderDriver(std::filesystem::path const& p)
     {
+        py::gil_scoped_acquire acquire;
         return StageFactory::inferReaderDriver(p.string());
     }
 
     std::string getWriterDriver(std::filesystem::path const& p)
     {
+        py::gil_scoped_acquire acquire;
         return StageFactory::inferWriterDriver(p.string());
     }
 
@@ -137,6 +142,7 @@ namespace pdal {
         }
 
         py::object getMetadata() {
+            py::gil_scoped_acquire acquire;
             py::object json = py::module_::import("json");
 
             std::stringstream strm;
@@ -184,6 +190,7 @@ namespace pdal {
         }
 
         void setInputs(std::vector<py::array> ndarrays) {
+            py::gil_scoped_acquire acquire;
             _inputs.clear();
             for (const auto& ndarray: ndarrays) {
                 PyArrayObject* ndarray_ptr = (PyArrayObject*)ndarray.ptr();
@@ -202,6 +209,7 @@ namespace pdal {
         std::string getSrsWKT2() { return getExecutor()->getSrsWKT2(); }
 
         py::object getQuickInfo() {
+            py::gil_scoped_acquire acquire;
             py::object json = py::module_::import("json");
 
             std::string response;
@@ -267,6 +275,7 @@ namespace pdal {
         void delExecutor() { _executor.reset(); }
 
         PipelineExecutor* getExecutor() {
+            py::gil_scoped_acquire acquire;
             if (!_executor)
                 _executor.reset(new PipelineExecutor(getJson(), _inputs, _loglevel));
             return _executor.get();

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -30,7 +30,6 @@ namespace pdal {
     };
 
    std::vector<py::dict> getDrivers() {
-        py::gil_scoped_acquire acquire;
         std::vector<py::dict> drivers;
 
         pdal::StageFactory f(false);
@@ -59,7 +58,6 @@ namespace pdal {
     };
 
    py::object getOptions() {
-        py::gil_scoped_acquire acquire;
         py::object json = py::module_::import("json");
         py::dict stageOptions;
 
@@ -94,7 +92,6 @@ namespace pdal {
     };
 
     std::vector<py::dict> getDimensions() {
-        py::gil_scoped_acquire acquire;
         py::object np = py::module_::import("numpy");
         py::object dtype = np.attr("dtype");
         std::vector<py::dict> dims;
@@ -112,13 +109,11 @@ namespace pdal {
 
     std::string getReaderDriver(std::filesystem::path const& p)
     {
-        py::gil_scoped_acquire acquire;
         return StageFactory::inferReaderDriver(p.string());
     }
 
     std::string getWriterDriver(std::filesystem::path const& p)
     {
-        py::gil_scoped_acquire acquire;
         return StageFactory::inferWriterDriver(p.string());
     }
 
@@ -142,7 +137,6 @@ namespace pdal {
         }
 
         py::object getMetadata() {
-            py::gil_scoped_acquire acquire;
             py::object json = py::module_::import("json");
 
             std::stringstream strm;
@@ -175,12 +169,7 @@ namespace pdal {
         }
 
         point_count_t executeStream(point_count_t streamLimit) {
-            point_count_t response(0);
-            {
-                py::gil_scoped_release release;
-                response = getExecutor()->executeStream(streamLimit);
-            }
-            return response;
+            return  getExecutor()->executeStream(streamLimit);
         }
 
         std::unique_ptr<PipelineIterator> iterator(int chunk_size, int prefetch) {
@@ -190,7 +179,6 @@ namespace pdal {
         }
 
         void setInputs(std::vector<py::array> ndarrays) {
-            py::gil_scoped_acquire acquire;
             _inputs.clear();
             for (const auto& ndarray: ndarrays) {
                 PyArrayObject* ndarray_ptr = (PyArrayObject*)ndarray.ptr();
@@ -209,7 +197,6 @@ namespace pdal {
         std::string getSrsWKT2() { return getExecutor()->getSrsWKT2(); }
 
         py::object getQuickInfo() {
-            py::gil_scoped_acquire acquire;
             py::object json = py::module_::import("json");
 
             std::string response;
@@ -275,7 +262,6 @@ namespace pdal {
         void delExecutor() { _executor.reset(); }
 
         PipelineExecutor* getExecutor() {
-            py::gil_scoped_acquire acquire;
             if (!_executor)
                 _executor.reset(new PipelineExecutor(getJson(), _inputs, _loglevel));
             return _executor.get();

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -207,7 +207,6 @@ namespace pdal {
         std::string getSrsWKT2() { return getExecutor()->getSrsWKT2(); }
 
         py::object getQuickInfo() {
-            py::gil_scoped_acquire acquire;
             py::object json = py::module_::import("json");
 
             std::string response;

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -30,7 +30,6 @@ namespace pdal {
     };
 
    std::vector<py::dict> getDrivers() {
-        py::gil_scoped_acquire acquire;
         std::vector<py::dict> drivers;
 
         pdal::StageFactory f(false);
@@ -59,7 +58,6 @@ namespace pdal {
     };
 
    py::object getOptions() {
-        py::gil_scoped_acquire acquire;
         py::object json = py::module_::import("json");
         py::dict stageOptions;
 
@@ -94,7 +92,6 @@ namespace pdal {
     };
 
     std::vector<py::dict> getDimensions() {
-        py::gil_scoped_acquire acquire;
         py::object np = py::module_::import("numpy");
         py::object dtype = np.attr("dtype");
         std::vector<py::dict> dims;
@@ -112,13 +109,11 @@ namespace pdal {
 
     std::string getReaderDriver(std::filesystem::path const& p)
     {
-        py::gil_scoped_acquire acquire;
         return StageFactory::inferReaderDriver(p.string());
     }
 
     std::string getWriterDriver(std::filesystem::path const& p)
     {
-        py::gil_scoped_acquire acquire;
         return StageFactory::inferWriterDriver(p.string());
     }
 
@@ -272,6 +267,7 @@ namespace pdal {
         void delExecutor() { _executor.reset(); }
 
         PipelineExecutor* getExecutor() {
+            py::gil_scoped_acquire acquire;
             if (!_executor)
                 _executor.reset(new PipelineExecutor(getJson(), _inputs, _loglevel));
             return _executor.get();

--- a/pdal/libpdalpython.cpp
+++ b/pdal/libpdalpython.cpp
@@ -142,7 +142,6 @@ namespace pdal {
         }
 
         py::object getMetadata() {
-            py::gil_scoped_acquire acquire;
             py::object json = py::module_::import("json");
 
             std::stringstream strm;


### PR DESCRIPTION
* `executeStream` already does GIL release
* pybind11 does GIL acquisition with each call, we don't need to be doing that everywhere