### PR TITLE
Add GeoDataFrame support to Pipeline

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - pdal
   - pytest
   - meshio
-  - pandas
+  - geopandas


### PR DESCRIPTION
GeoDataFrame support added for if GeoPandas is available.

GeoPandas import mirrors existing Pandas import.

Pipeline.get_geodataframe method added. Users can get an array from an executed pipeline as a GeoDataFrame instead of a Pandas DataFrame. Optional arguments included for specifying XY vs XYZ point geometries and for providing CRS information to the GeoDataFrame constructor.

Pipeline(dataframes) modified so that columns named "geometry" will be dropped before conversion to structured arrays.