### PR TITLE
Adding support for streaming through the input arrays of a pipeline

### DIFF
--- a/src/pdal/PyArray.cpp
+++ b/src/pdal/PyArray.cpp
@@ -34,7 +34,6 @@
 
 #include "PyArray.hpp"
 #include <pdal/io/MemoryViewReader.hpp>
-#include <numpy/arrayobject.h>
 
 namespace pdal
 {
@@ -95,7 +94,8 @@ std::string pyObjectToString(PyObject *pname)
   #define PyDataType_NAMES(descr) ((descr)->names)
 #endif
 
-Array::Array(PyArrayObject* array) : m_array(array), m_rowMajor(true)
+Array::Array(PyArrayObject* array, std::shared_ptr<ArrayStreamHandler> stream_handler)
+    : m_array(array), m_rowMajor(true), m_stream_handler(std::move(stream_handler))
 {
     Py_XINCREF(array);
 
@@ -164,40 +164,69 @@ Array::~Array()
     Py_XDECREF(m_array);
 }
 
-
-ArrayIter& Array::iterator()
+std::shared_ptr<ArrayIter> Array::iterator()
 {
-    ArrayIter *it = new ArrayIter(m_array);
-    m_iterators.emplace_back((it));
-    return *it;
+    return std::make_shared<ArrayIter>(m_array, m_stream_handler);
 }
 
-
-ArrayIter::ArrayIter(PyArrayObject* np_array)
+ArrayIter::ArrayIter(PyArrayObject* np_array, std::shared_ptr<ArrayStreamHandler> stream_handler)
+    : m_stream_handler(std::move(stream_handler))
 {
-    m_iter = NpyIter_New(np_array,
-        NPY_ITER_EXTERNAL_LOOP | NPY_ITER_READONLY | NPY_ITER_REFS_OK,
-        NPY_KEEPORDER, NPY_NO_CASTING, NULL);
-    if (!m_iter)
-        throw pdal_error("Unable to create numpy iterator.");
+    resetIterator(np_array);
+}
+
+void ArrayIter::resetIterator(std::optional<PyArrayObject*> np_array = {})
+{
+    std::optional<int> stream_chunk_size = std::nullopt;
+    if (m_stream_handler) {
+        stream_chunk_size = (*m_stream_handler)();
+        if (*stream_chunk_size == 0) {
+            m_done = true;
+            return;
+        }
+    }
+
+    if (np_array) {
+        // Init iterator
+        m_iter = NpyIter_New(np_array.value(),
+                             NPY_ITER_EXTERNAL_LOOP | NPY_ITER_READONLY | NPY_ITER_REFS_OK,
+                             NPY_KEEPORDER, NPY_NO_CASTING, NULL);
+        if (!m_iter)
+            throw pdal_error("Unable to create numpy iterator.");
+    } else {
+        // Otherwise, reset the iterator to the initial state
+        if (NpyIter_Reset(m_iter, NULL) != NPY_SUCCEED) {
+            NpyIter_Deallocate(m_iter);
+            throw pdal_error("Unable to reset numpy iterator.");
+        }
+    }
 
     char *itererr;
     m_iterNext = NpyIter_GetIterNext(m_iter, &itererr);
     if (!m_iterNext)
     {
         NpyIter_Deallocate(m_iter);
-        throw pdal_error(std::string("Unable to create numpy iterator: ") +
-            itererr);
+        throw pdal_error(std::string("Unable to create numpy iterator: ") + itererr);
     }
     m_data = NpyIter_GetDataPtrArray(m_iter);
-    m_stride = NpyIter_GetInnerStrideArray(m_iter);
-    m_size = NpyIter_GetInnerLoopSizePtr(m_iter);
+    m_stride = *NpyIter_GetInnerStrideArray(m_iter);
+    m_size = *NpyIter_GetInnerLoopSizePtr(m_iter);
+    if (stream_chunk_size) {
+        if (0 <= *stream_chunk_size && *stream_chunk_size <= m_size) {
+            m_size = *stream_chunk_size;
+        } else {
+            throw pdal_error(std::string("Stream chunk size not in the range of array length: ") +
+                             std::to_string(*stream_chunk_size));
+        }
+    }
     m_done = false;
 }
 
 ArrayIter::~ArrayIter()
 {
-    NpyIter_Deallocate(m_iter);
+    if (m_iter != nullptr) {
+        NpyIter_Deallocate(m_iter);
+    }
 }
 
 ArrayIter& ArrayIter::operator++()
@@ -205,10 +234,15 @@ ArrayIter& ArrayIter::operator++()
     if (m_done)
         return *this;
 
-    if (--(*m_size))
-        *m_data += *m_stride;
-    else if (!m_iterNext(m_iter))
-        m_done = true;
+    if (--m_size) {
+        *m_data += m_stride;
+    } else if (!m_iterNext(m_iter)) {
+        if (m_stream_handler) {
+            resetIterator();
+        } else {
+            m_done = true;
+        }
+    }
     return *this;
 }
 

--- a/src/pdal/PyArray.hpp
+++ b/src/pdal/PyArray.hpp
@@ -49,7 +49,6 @@
 
 #include <vector>
 #include <memory>
-#include <optional>
 
 namespace pdal
 {
@@ -112,7 +111,8 @@ private:
     bool m_done;
 
     std::shared_ptr<ArrayStreamHandler> m_stream_handler;
-    void resetIterator(std::optional<PyArrayObject*> np_array);
+    void initIterator();
+    void resetIterator();
 };
 
 } // namespace python

--- a/src/pdal/PyArray.hpp
+++ b/src/pdal/PyArray.hpp
@@ -49,6 +49,7 @@
 
 #include <vector>
 #include <memory>
+#include <optional>
 
 namespace pdal
 {
@@ -58,6 +59,7 @@ namespace python
 
 class ArrayIter;
 
+using ArrayStreamHandler = std::function<int64_t()>;
 
 class PDAL_DLL Array
 {
@@ -65,7 +67,7 @@ public:
     using Shape = std::array<size_t, 3>;
     using Fields = std::vector<MemoryViewReader::Field>;
 
-    Array(PyArrayObject* array);
+    Array(PyArrayObject* array, std::shared_ptr<ArrayStreamHandler> stream_handler = {});
     ~Array();
 
     Array(Array&& a) = default;
@@ -77,14 +79,14 @@ public:
     bool rowMajor() const { return m_rowMajor; };
     Shape shape() const { return m_shape; }
     const Fields& fields() const { return m_fields; };
-    ArrayIter& iterator();
+    std::shared_ptr<ArrayIter> iterator();
 
 private:
     PyArrayObject* m_array;
     Fields m_fields;
     bool m_rowMajor;
     Shape m_shape {};
-    std::vector<std::unique_ptr<ArrayIter>> m_iterators;
+    std::shared_ptr<ArrayStreamHandler> m_stream_handler;
 };
 
 
@@ -94,7 +96,7 @@ public:
     ArrayIter(const ArrayIter&) = delete;
     ArrayIter() = delete;
 
-    ArrayIter(PyArrayObject*);
+    ArrayIter(PyArrayObject*, std::shared_ptr<ArrayStreamHandler>);
     ~ArrayIter();
 
     ArrayIter& operator++();
@@ -102,12 +104,15 @@ public:
     char* operator*() const { return *m_data; }
 
 private:
-    NpyIter *m_iter;
+    NpyIter *m_iter = nullptr;
     NpyIter_IterNextFunc *m_iterNext;
     char **m_data;
-    npy_intp *m_size;
-    npy_intp *m_stride;
+    npy_intp m_size;
+    npy_intp m_stride;
     bool m_done;
+
+    std::shared_ptr<ArrayStreamHandler> m_stream_handler;
+    void resetIterator(std::optional<PyArrayObject*> np_array);
 };
 
 } // namespace python

--- a/src/pdal/PyPipeline.cpp
+++ b/src/pdal/PyPipeline.cpp
@@ -245,14 +245,20 @@ void PipelineExecutor::addArrayReaders(std::vector<std::shared_ptr<Array>> array
         for (auto f : array->fields())
             r.pushField(f);
 
-        ArrayIter& iter = array->iterator();
-        auto incrementer = [&iter](PointId id) -> char *
+        auto arrayIter = array->iterator();
+        auto incrementer = [arrayIter, firstPoint = true](PointId id) mutable -> char *
         {
-            if (! iter)
+            ArrayIter& iter = *arrayIter;
+            if (!firstPoint && iter) {
+                ++iter;
+            } else {
+                firstPoint = false;
+            }
+
+            if (!iter)
                 return nullptr;
 
             char *c = *iter;
-            ++iter;
             return c;
         };
 


### PR DESCRIPTION
I've faced a couple of cases where I wasn't able to fit all my input data in memory to then run a (streamed) PDAL pipeline with it.

With these changes, you'd be able to stream the input data into the Pipeline. This has helped me:
* To relieve memory requirements from certain pipelines
* Enable the streaming of data provided by libraries that support it (ex: [pye57](https://github.com/davidcaron/pye57) or pdal itself)

See below a very simple example of usage just for illustrative purposes.

<details>
  <summary>
Streaming the read and write of a very large LAZ file. <br/>
With support for tweaking both input and output chunk sizes
</summary>

  ```python
import numpy as np
import pdal

def run():
    in_chunk_size = 10_000_000
    in_pipeline = pdal.Reader.las(**{
        "filename": "in_test.laz"
    }).pipeline()

    in_pipeline_it = in_pipeline.iterator(in_chunk_size).__iter__()

    out_chunk_size = 50_000_000
    out_file = "out_test.laz"
    out_pipeline = pdal.Writer.las(
        filename=out_file
    ).pipeline()

    out_buffer = np.zeros(in_chunk_size, dtype=[("X", float), ("Y", float), ("Z", float)])

    def load_next_chunk():
        try:
            next_chunk = next(in_pipeline_it)
        except StopIteration:
            # Stops the streaming
            return 0

        chunk_size = next_chunk.size
        out_buffer[:chunk_size]["X"] = next_chunk[:]["X"]
        out_buffer[:chunk_size]["Y"] = next_chunk[:]["Y"]
        out_buffer[:chunk_size]["Z"] = next_chunk[:]["Z"]

        print(f"Loaded next chunk -> {chunk_size}")

        return chunk_size

    out_pipeline.inputs = [(out_buffer, load_next_chunk)]

    out_pipeline.loglevel = 20 # INFO
    count = out_pipeline.execute_streaming(out_chunk_size)

    print(f"\nWROTE - {count}")

if __name__ == "__main__":
    import timeit
    time_taken = timeit.timeit(stmt=run, number=1)
    print(f"Time taken: {time_taken:.4f} seconds")
  ```
</details>