### PR TITLE
Support limiting dimensions with execute() and executeStreaming()

### DIFF
--- a/src/pdal/PyArray.cpp
+++ b/src/pdal/PyArray.cpp
@@ -78,7 +78,7 @@ Dimension::Type pdalType(int t)
     return Type::None;
 }
 
-std::string toString(PyObject *pname)
+std::string pyObjectToString(PyObject *pname)
 {
     PyObject* r = PyObject_Str(pname);
     if (!r)
@@ -92,6 +92,7 @@ std::string toString(PyObject *pname)
 
 #if NPY_ABI_VERSION < 0x02000000
   #define PyDataType_FIELDS(descr) ((descr)->fields)
+  #define PyDataType_NAMES(descr) ((descr)->names)
 #endif
 
 Array::Array(PyArrayObject* array) : m_array(array), m_rowMajor(true)
@@ -124,7 +125,7 @@ Array::Array(PyArrayObject* array) : m_array(array), m_rowMajor(true)
 
         for (int i = 0; i < numFields; ++i)
         {
-            std::string name = toString(PyList_GetItem(names, i));
+            std::string name = python::pyObjectToString(PyList_GetItem(names, i));
             if (name == "X")
                 xyz |= 1;
             else if (name == "Y")

--- a/src/pdal/PyArray.hpp
+++ b/src/pdal/PyArray.hpp
@@ -55,6 +55,7 @@ namespace pdal
 namespace python
 {
 
+
 class ArrayIter;
 
 
@@ -87,7 +88,7 @@ private:
 };
 
 
-class ArrayIter
+class PDAL_DLL ArrayIter
 {
 public:
     ArrayIter(const ArrayIter&) = delete;

--- a/src/pdal/PyPipeline.cpp
+++ b/src/pdal/PyPipeline.cpp
@@ -73,8 +73,13 @@ PipelineExecutor::PipelineExecutor(
 }
 
 
-point_count_t PipelineExecutor::execute()
+point_count_t PipelineExecutor::execute(pdal::StringList allowedDims)
 {
+    if (allowedDims.size())
+    {
+        m_manager.pointTable().layout()->setAllowedDims(allowedDims);
+    }
+
     point_count_t count = m_manager.execute();
     m_executed = true;
     return count;
@@ -92,9 +97,14 @@ std::string PipelineExecutor::getSrsWKT2() const
     return output;
 }
 
-point_count_t PipelineExecutor::executeStream(point_count_t streamLimit)
+point_count_t PipelineExecutor::executeStream(point_count_t streamLimit,
+                                              pdal::StringList allowedDims)
 {
     CountPointTable table(streamLimit);
+    if (allowedDims.size())
+    {
+        pointTable().layout()->setAllowedDims(allowedDims);
+    }
     m_manager.executeStream(table);
     m_executed = true;
     return table.count();
@@ -272,6 +282,7 @@ PyObject* buildNumpyDescriptor(PointLayoutPtr layout)
     {
         return layout->dimOffset(id1) < layout->dimOffset(id2);
     };
+
     auto dims = layout->dims();
     std::sort(dims.begin(), dims.end(), sortByOffset);
 

--- a/src/pdal/PyPipeline.hpp
+++ b/src/pdal/PyPipeline.hpp
@@ -60,8 +60,8 @@ public:
     PipelineExecutor(std::string const& json, std::vector<std::shared_ptr<Array>> arrays, int level);
     virtual ~PipelineExecutor() = default;
 
-    point_count_t execute();
-    point_count_t executeStream(point_count_t streamLimit);
+    point_count_t execute(pdal::StringList allowedDims);
+    point_count_t executeStream(point_count_t streamLimit, pdal::StringList allowedDims);
 
     const PointViewSet& views() const;
     std::string getPipeline() const;

--- a/src/pdal/StreamableExecutor.cpp
+++ b/src/pdal/StreamableExecutor.cpp
@@ -187,11 +187,17 @@ StreamableExecutor::StreamableExecutor(std::string const& json,
                                        std::vector<std::shared_ptr<Array>> arrays,
                                        int level,
                                        point_count_t chunkSize,
-                                       int prefetch)
+                                       int prefetch,
+                                       pdal::StringList allowedDims)
     : PipelineExecutor(json, arrays, level)
     , m_table(chunkSize, prefetch)
     , m_exc(nullptr)
 {
+
+    if (allowedDims.size())
+    {
+        m_table.layout()->setAllowedDims(allowedDims);
+    }
     m_thread.reset(new std::thread([this]()
     {
         try {

--- a/src/pdal/StreamableExecutor.hpp
+++ b/src/pdal/StreamableExecutor.hpp
@@ -81,7 +81,8 @@ public:
                        std::vector<std::shared_ptr<Array>> arrays,
                        int level,
                        point_count_t chunkSize,
-                       int prefetch);
+                       int prefetch,
+                       pdal::StringList allowedDim);
     ~StreamableExecutor();
 
     MetadataNode getMetadata() { return m_table.metadata(); }

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -82,6 +82,17 @@ class TestPipeline:
         count2 = r.execute_streaming(chunk_size=100)
         assert count == count2
 
+
+    @pytest.mark.parametrize("filename", ["range.json", "range.py"])
+    def test_subsetstreaming(self, filename):
+        """Can we fetch a subset of PDAL dimensions as a numpy array while streaming"""
+        r = get_pipeline(filename)
+        limit = ['X','Y','Z','Intensity']
+        arrays = list(r.iterator(chunk_size=100,allowed_dims=limit))
+        assert len(arrays) == 11
+        assert len(arrays[0].dtype) == 4
+
+
     @pytest.mark.parametrize("filename", ["sort.json", "sort.py"])
     def test_execute_streaming_non_streamable(self, filename):
         r = get_pipeline(filename)
@@ -112,6 +123,18 @@ class TestPipeline:
         a = arrays[0]
         assert a[0][0] == 635619.85
         assert a[1064][2] == 456.92
+
+    @pytest.mark.parametrize("filename", ["sort.json", "sort.py"])
+    def test_subsetarray(self, filename):
+        """Can we fetch a subset of PDAL dimensions as a numpy array"""
+        r = get_pipeline(filename)
+        limit = ['X','Y','Z']
+        r.execute(allowed_dims=limit)
+        arrays = r.arrays
+        assert len(arrays) == 1
+        assert len(arrays[0].dtype) == 3
+
+
 
     @pytest.mark.parametrize("filename", ["sort.json", "sort.py"])
     def test_metadata(self, filename):


### PR DESCRIPTION
This PR implements support for filtering the allowed dimensions used by pipelines in `execute` and `executeStreaming`. See the test for inspiration how to use it.

 