### PR TITLE
use PDAL_EXPORT instead of PDAL_DLL

### DIFF
--- a/src/pdal/PyArray.hpp
+++ b/src/pdal/PyArray.hpp
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <pdal/util/pdal_util_export.hpp>
 #include <pdal/PointView.hpp>
 
 #define NPY_TARGET_VERSION NPY_1_22_API_VERSION
@@ -60,7 +61,7 @@ class ArrayIter;
 
 using ArrayStreamHandler = std::function<int64_t()>;
 
-class PDAL_DLL Array
+class PDAL_EXPORT Array
 {
 public:
     using Shape = std::array<size_t, 3>;
@@ -89,7 +90,7 @@ private:
 };
 
 
-class PDAL_DLL ArrayIter
+class PDAL_EXPORT ArrayIter
 {
 public:
     ArrayIter(const ArrayIter&) = delete;

--- a/src/pdal/PyPipeline.hpp
+++ b/src/pdal/PyPipeline.hpp
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <pdal/util/pdal_util_export.hpp>
 #include <pdal/PipelineManager.hpp>
 
 #define NPY_TARGET_VERSION NPY_1_22_API_VERSION
@@ -55,7 +56,7 @@ PyArrayObject* meshToNumpyArray(const TriangularMesh* mesh);
 
 class Array;
 
-class PDAL_DLL PipelineExecutor {
+class PDAL_EXPORT PipelineExecutor {
 public:
     PipelineExecutor(std::string const& json, std::vector<std::shared_ptr<Array>> arrays, int level);
     virtual ~PipelineExecutor() = default;


### PR DESCRIPTION

PDAL 2.9 renamed PDAL_DLL to PDAL_EXPORT in https://github.com/PDAL/PDAL/issues/2685 It also included a synonym in the header for older versions.